### PR TITLE
Set env var to fix issue with MKL_THREADING_LAYER

### DIFF
--- a/rslp/launch_beaker.py
+++ b/rslp/launch_beaker.py
@@ -72,6 +72,10 @@ def launch_job(
                 name="RSLP_BUCKET",
                 value=os.environ["RSLP_BUCKET"],
             ),
+            EnvVar(
+                name="MKL_THREADING_LAYER",
+                value="GNU",
+            ),
         ]
         if username:
             env_vars.append(


### PR DESCRIPTION
When running Maldives on beaker, got this error: 

```
2024-09-05T19:41:11.257738912Z Error: mkl-service + Intel(R) MKL: MKL_THREADING_LAYER=INTEL is incompatible with libgomp.so.1 library.
2024-09-05T19:41:11.257764641Z 	Try to import numpy first or set the threading layer accordingly. Set MKL_SERVICE_FORCE_INTEL to force it.
```

This typically happens when multiple libraries (such as numpy, scipy, or pytorch) are linked to different threading libraries. 
The fix here is to export MKL_THREADING_LAYER=GNU. We can handle this issue later via library versions. 