### PR TITLE
Speedup dataloader initialization by setting forkserver preload

### DIFF
--- a/rslp/rslearn_main.py
+++ b/rslp/rslearn_main.py
@@ -22,4 +22,22 @@ def main():
 
 if __name__ == "__main__":
     multiprocessing.set_start_method("forkserver")
+    multiprocessing.set_forkserver_preload(
+        [
+            "pickle",
+            "fiona",
+            "gcsfs",
+            "jsonargparse",
+            "numpy",
+            "PIL",
+            "torch",
+            "torch.multiprocessing",
+            "torchvision",
+            "upath",
+            "wandb",
+            "rslearn.main",
+            "rslearn.train.dataset",
+            "rslearn.train.data_module",
+        ]
+    )
     main()


### PR DESCRIPTION
Speedup dataloader initialization by setting forkserver preload

Currently sometimes dataloader workers take 4 sec to start each, and it is
sequential for some reason, so it can take a couple minutes to get all the
workers.

Some of the time is spent importing modules. With forkserver start method
(which we are using), preload parameter can be set to load modules in the
forkserver process, this way it eliminates the import time in the child
process.

So this commit adds a bunch of modules to forkserver preload setting and it
now only takes about 0.4 sec to start each worker which is still a long time
but at least much better than before. The remaining time seems to not be related
to importing modules.
