### PR TITLE
fix problem with model fit with no RSLP_RUN_ID set

### DIFF
--- a/rslp/launcher_lib.py
+++ b/rslp/launcher_lib.py
@@ -126,14 +126,14 @@ def download_code(project_id: str, experiment_id: str) -> None:
 
 
 def upload_wandb_id(
-    project_id: str, experiment_id: str, run_id: str, wandb_id: str
+    project_id: str, experiment_id: str, run_id: str | None, wandb_id: str
 ) -> None:
     """Save a W&B run ID to GCS.
 
     Args:
         project_id: the project ID.
         experiment_id: the experiment ID.
-        run_id: the run ID (for hyperparameter experiments)
+        run_id: optional run ID (for hyperparameter experiments)
         wandb_id: the W&B run ID.
     """
     rslp_prefix = UPath(os.environ["RSLP_PREFIX"])

--- a/rslp/lightning_cli.py
+++ b/rslp/lightning_cli.py
@@ -21,7 +21,7 @@ CHECKPOINT_DIR = (
 class SaveWandbRunIdCallback(Callback):
     """Callback to save the wandb run ID to GCS in case of resume."""
 
-    def __init__(self, project_id: str, experiment_id: str, run_id: str) -> None:
+    def __init__(self, project_id: str, experiment_id: str, run_id: str | None) -> None:
         """Create a new SaveWandbRunIdCallback.
 
         Args:


### PR DESCRIPTION
#63 made it okay to have None run_id but it didn't have change for training.

With this one I think `model fit` is working.

I think in #63 it would've worked with fewer changes needed to have the default (`os.environ.get("RSLP_RUN_ID", ...)`) be `""` instead of `None` but I think `None` is better anyway.