### PR TITLE
bump base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime@sha256:58a28ab734f23561aa146fbaf777fb319a953ca1e188832863ed57d510c9f197
+FROM pytorch/pytorch:2.5.0-cuda11.8-cudnn9-runtime@sha256:d15e9803095e462e351f097fb1f5e7cdaa4f5e855d7ff6d6f36ec4c2aa2938ea
 
 RUN apt update
 RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git


### PR DESCRIPTION
rslearn requires torch>=2.5 so we were reinstalling torch and cuda 12.1 stuff on top of the stuff in the base image, which was taking up unneeded time and space