### PR TITLE
Fix Landsat performance issue by using nearest neighbor interpolation

### DIFF
--- a/data/landsat_vessels/predict_dataset_config.json
+++ b/data/landsat_vessels/predict_dataset_config.json
@@ -154,6 +154,7 @@
         "name": "rslearn.data_sources.local_files.LocalFiles",
         "src_dir": "PLACEHOLDER"
       },
+      "resampling_method": "nearest",
       "type": "raster"
     },
     "output": {

--- a/data/landsat_vessels/predict_dataset_config_aws.json
+++ b/data/landsat_vessels/predict_dataset_config_aws.json
@@ -154,6 +154,7 @@
         "metadata_cache_dir": "cache/landsat",
         "name": "rslearn.data_sources.aws_landsat.LandsatOliTirs"
       },
+      "resampling_method": "nearest",
       "type": "raster"
     },
     "output": {

--- a/rslp/main.py
+++ b/rslp/main.py
@@ -3,11 +3,9 @@
 import argparse
 import importlib
 import sys
-from pathlib import Path
 
 import dotenv
 import jsonargparse
-from jsonargparse import ActionConfigFile
 
 from rslp.log_utils import get_logger
 from rslp.utils.mp import init_mp
@@ -15,30 +13,10 @@ from rslp.utils.mp import init_mp
 logger = get_logger(__name__)
 
 
-class RelativePathActionConfigFile(ActionConfigFile):
-    """Custom action to handle relative paths to config files."""
-
-    def __call__(
-        self,
-        parser: jsonargparse.ArgumentParser,
-        namespace: argparse.Namespace,
-        values: str,
-        option_string: str | None = None,
-    ) -> None:
-        """Convert relative paths to absolute before loading config."""
-        if not str(values).startswith(("/", "gs://")):
-            repo_root = (
-                Path(__file__).resolve().parents[1]
-            )  # Go up to rslearn_projects root
-            values = str(repo_root / values)
-        super().__call__(parser, namespace, values, option_string)
-
-
 def main() -> None:
     """Main entrypoint function for rslp."""
     dotenv.load_dotenv()
     parser = argparse.ArgumentParser(description="rslearn")
-    parser.register("action", "config_file", RelativePathActionConfigFile)
     parser.add_argument("project", help="The project to execute a workflow for.")
     parser.add_argument("workflow", help="The name of the workflow.")
     args = parser.parse_args(args=sys.argv[1:3])
@@ -47,9 +25,6 @@ def main() -> None:
     workflow_fn = module.workflows[args.workflow]
     logger.info(f"running {args.workflow} for {args.project}")
     logger.info(f"args: {sys.argv[3:]}")
-
-    # Enable relative path support for config files
-    jsonargparse.set_config_read_mode("default")
     jsonargparse.CLI(workflow_fn, args=sys.argv[3:])
 
 


### PR DESCRIPTION
Both Landsat models are currently trained on a dataset that was materialized before https://github.com/allenai/rslearn/pull/104. Because Landsat scenes are not pixel-aligned (x/y offset in CRS coordinates are not multiples of the m/pixel resolution), this means that:

* Before the change, the offset was rounded to the nearest integer. This is not really correct, but in this case it corresponds roughly to nearest neighbor interpolation.
* After the change, the default is to do bilinear resampling to compute the values of the pixels on pixel-aligned grid against those from the source images (which for Landsat are on an offset grid).

There seems to be a performance drop due to the discrepancy.

Bilinear:
```
Expected detections between 200 and 500, Actual detections: 447 
Expected detections between 0 and 10, Actual detections: 9 
Expected detections between 0 and 10, Actual detections: 4 
Expected detections between 200 and 500, Actual detections: 292 
Expected detections between 0 and 10, Actual detections: 0 
Expected detections between 0 and 10, Actual detections: 0 
Expected detections between 0 and 10, Actual detections: 1 
Expected detections between 200 and 500, Actual detections: 366 
Expected detections between 20 and 50, Actual detections: 19 
Expected detections between 0 and 10, Actual detections: 2 
Expected detections between 0 and 10, Actual detections: 3 
Expected detections between 20 and 50, Actual detections: 31 
Expected detections between 0 and 10, Actual detections: 8 
Expected detections between 0 and 10, Actual detections: 5 
Expected detections between 20 and 50, Actual detections: 20 
Pass: 14, Fail: 1, Pass %: 93.33
```

Original results:
```
Expected detections between 200 and 500, Actual detections: 443 
Expected detections between 0 and 10, Actual detections: 8 
Expected detections between 0 and 10, Actual detections: 3 
Expected detections between 200 and 500, Actual detections: 363 
Expected detections between 0 and 10, Actual detections: 0 
Expected detections between 0 and 10, Actual detections: 3 
Expected detections between 0 and 10, Actual detections: 1 
Expected detections between 200 and 500, Actual detections: 449 
Expected detections between 20 and 50, Actual detections: 30 
Expected detections between 0 and 10, Actual detections: 1 
Expected detections between 0 and 10, Actual detections: 3 
Expected detections between 20 and 50, Actual detections: 35 
Expected detections between 0 and 10, Actual detections: 10 
Expected detections between 0 and 10, Actual detections: 9 
Expected detections between 20 and 50, Actual detections: 45 
Pass: 15, Fail: 0, Pass %: 100.00
```

We could retrain the model, but nearest neighbor interpolation produces sharper images for human visualization (which Skylight wants), and it is convenient to use the same images for inference and for visualization. It seems there's no need for retraining to use nearest neighbor interpolation:

```
Expected detections between 200 and 500, Actual detections: 396 
Expected detections between 0 and 10, Actual detections: 8 
Expected detections between 0 and 10, Actual detections: 4 
Expected detections between 200 and 500, Actual detections: 368 
Expected detections between 0 and 10, Actual detections: 0 
Expected detections between 0 and 10, Actual detections: 4 
Expected detections between 0 and 10, Actual detections: 0 
Expected detections between 200 and 500, Actual detections: 404 
Expected detections between 20 and 50, Actual detections: 27 
Expected detections between 0 and 10, Actual detections: 1 
Expected detections between 0 and 10, Actual detections: 3 
Expected detections between 20 and 50, Actual detections: 35 
Expected detections between 0 and 10, Actual detections: 9 
Expected detections between 0 and 10, Actual detections: 7 
Expected detections between 20 and 50, Actual detections: 41 
Pass: 15, Fail: 0, Pass %: 100.00
```

I guess the performance discrepancy is pretty small but anyway this change will align the inference closer to the training and also restore the sharpness of the pan-sharpened images (we could create another layer for visualization but it seems worse to maintain long-term).

I also removed relative path action since it broke the `rslp.landsat_vessels.job_launcher` functionality (job_launcher passes `--config "{JSON}` but the relative path action interprets the JSON as a path and prepends some absolute path to it). This action doesn't seem to be used anywhere and makes it confusing because the user can no longer cd to a directory outside of `rslearn_projects` and run their own config file they have put in that directory unless they use absolute path, instead it will assume by default that they want to run a config from inside the rslearn_projects directory (I think this is unintuitive).