### PR TITLE
Run publish_project_docker_image.yaml reusable workflow from current branch

### DIFF
--- a/.github/workflows/landsat_vessel.yaml
+++ b/.github/workflows/landsat_vessel.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: allenai/rslearn_projects/.github/workflows/publish_project_docker_image.yaml@master
+    uses: ./.github/workflows/publish_project_docker_image.yaml
     with:
       rslp_project: "landsat_vessels"
       image_name: "landsat-vessel-detection"

--- a/.github/workflows/sentinel2_vessel.yaml
+++ b/.github/workflows/sentinel2_vessel.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: allenai/rslearn_projects/.github/workflows/publish_project_docker_image.yaml@favyen/sentinel2_detector_update
+    uses: ./.github/workflows/publish_project_docker_image.yaml
     with:
       rslp_project: "sentinel2_vessels"
       image_name: "sentinel2-vessel-detection"


### PR DESCRIPTION
Run publish_project_docker_image.yaml reusable workflow from current branch.

Currently in master branch it is not working because for testing in previous PR I had it refer to the PR branch which is now deleted.

The change uses a different syntax that allows using reusable workflow in current branch (whichever one is executing the Action) rather than needing to refer to a specific branch.