### PR TITLE
add prometheus timers to landsat-rslearn

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,10 +21,10 @@ jobs:
         with:
           lfs: false
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10.10
+          python-version: 3.11.10
           pip-version: 24
 
       - name: Linting

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi>=0.115
 google-cloud-bigtable>=2.18
 google-cloud-pubsub>=2.18
 interrogate>=1.7
+prometheus-client>=0.21.1
 pydantic>=2.8
 pytest>=8.2
 python-dotenv>=1.0

--- a/rslp/landsat_vessels/api_main.py
+++ b/rslp/landsat_vessels/api_main.py
@@ -212,9 +212,10 @@ async def get_detections(info: LandsatRequest, response: Response) -> LandsatRes
             error_message=f"Unexpected error in prediction pipeline: {e}",
         )
 
+
 # Setup prometheus
 def _setup_prom_metrics() -> Any:
-    multi_proc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
+    multi_proc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
     if not multi_proc_dir:
         # If we're not using multiproc, then just use the default registry
         return make_asgi_app()

--- a/rslp/landsat_vessels/api_main.py
+++ b/rslp/landsat_vessels/api_main.py
@@ -6,13 +6,17 @@ import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from enum import Enum
+from typing import Any
 
+import prometheus_client
 import uvicorn
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Response
+from prometheus_client import make_asgi_app, multiprocess
 from pydantic import BaseModel
 
 from rslp.landsat_vessels.predict_pipeline import FormattedPrediction, predict_pipeline
+from rslp.landsat_vessels.prom_metrics import time_operation, TimerOperations
 from rslp.log_utils import get_logger
 from rslp.utils.mp import init_mp
 
@@ -179,14 +183,15 @@ async def get_detections(info: LandsatRequest, response: Response) -> LandsatRes
         )
     try:
         logger.info("Processing request with input data.")
-        json_data = predict_pipeline(
-            scene_id=info.scene_id,
-            scene_zip_path=info.scene_zip_path,
-            image_files=info.image_files,
-            json_path=info.json_path,
-            scratch_path=info.scratch_path,
-            crop_path=info.crop_path,
-        )
+        with time_operation(TimerOperations.TotalInferenceTime):
+            json_data = predict_pipeline(
+                scene_id=info.scene_id,
+                scene_zip_path=info.scene_zip_path,
+                image_files=info.image_files,
+                json_path=info.json_path,
+                scratch_path=info.scratch_path,
+                crop_path=info.crop_path,
+            )
         return LandsatResponse(
             status=StatusEnum.SUCCESS,
             predictions=json_data,
@@ -206,6 +211,28 @@ async def get_detections(info: LandsatRequest, response: Response) -> LandsatRes
             predictions=[],
             error_message=f"Unexpected error in prediction pipeline: {e}",
         )
+
+# Setup prometheus
+def setup_prom_metrics() -> Any:
+    multi_proc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
+    if not multi_proc_dir:
+        # If we're not using multiproc, then just use the default registry
+        return make_asgi_app()
+
+    # Otherwise setup prometheus multiproc mode.
+    if os.path.isdir(multi_proc_dir):
+        for multi_proc_file in os.scandir(multi_proc_dir):
+            os.remove(multi_proc_file.path)
+    else:
+        os.makedirs(multi_proc_dir)
+
+    # Create the multiproc collector, and set it up to be connected to fastapi
+    registry = prometheus_client.CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry, path=multi_proc_dir)
+    return make_asgi_app(registry=registry)
+
+
+app.mount("/metrics", setup_prom_metrics())
 
 
 if __name__ == "__main__":

--- a/rslp/landsat_vessels/api_main.py
+++ b/rslp/landsat_vessels/api_main.py
@@ -16,7 +16,7 @@ from prometheus_client import make_asgi_app, multiprocess
 from pydantic import BaseModel
 
 from rslp.landsat_vessels.predict_pipeline import FormattedPrediction, predict_pipeline
-from rslp.landsat_vessels.prom_metrics import time_operation, TimerOperations
+from rslp.landsat_vessels.prom_metrics import TimerOperations, time_operation
 from rslp.log_utils import get_logger
 from rslp.utils.mp import init_mp
 
@@ -213,7 +213,7 @@ async def get_detections(info: LandsatRequest, response: Response) -> LandsatRes
         )
 
 # Setup prometheus
-def setup_prom_metrics() -> Any:
+def _setup_prom_metrics() -> Any:
     multi_proc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
     if not multi_proc_dir:
         # If we're not using multiproc, then just use the default registry
@@ -232,7 +232,7 @@ def setup_prom_metrics() -> Any:
     return make_asgi_app(registry=registry)
 
 
-app.mount("/metrics", setup_prom_metrics())
+app.mount("/metrics", _setup_prom_metrics())
 
 
 if __name__ == "__main__":

--- a/rslp/landsat_vessels/predict_pipeline.py
+++ b/rslp/landsat_vessels/predict_pipeline.py
@@ -454,7 +454,9 @@ def predict_pipeline(
     with time_operation(TimerOperations.GetVesselDetections):
         detections = get_vessel_detections(ds_path, scene_data)
     with time_operation(TimerOperations.RunClassifier):
-        detections = run_classifier(ds_path, detections=detections, scene_data=scene_data)
+        detections = run_classifier(
+            ds_path, detections=detections, scene_data=scene_data
+        )
 
     with time_operation(TimerOperations.BuildPredictionsAndCrops):
         json_data = _build_predictions_and_crops(detections, crop_path)
@@ -479,7 +481,10 @@ def predict_pipeline(
 
     return json_data
 
-def _build_predictions_and_crops(detections: list[VesselDetection], crop_path: str | None) -> list[FormattedPrediction]:
+
+def _build_predictions_and_crops(
+    detections: list[VesselDetection], crop_path: str | None
+) -> list[FormattedPrediction]:
     # Write JSON and crops.
     if crop_path:
         crop_upath = UPath(crop_path)
@@ -513,13 +518,18 @@ def _build_predictions_and_crops(detections: list[VesselDetection], crop_path: s
         )
     return json_data
 
+
 @dataclass
 class DetectionCrop:
     """Dataclass for return type from generating crops."""
+
     rgb_fname: UPath
     b8_fname: UPath
 
-def _write_detection_crop(detection: VesselDetection, crop_upath: UPath, idx: int) -> DetectionCrop:
+
+def _write_detection_crop(
+    detection: VesselDetection, crop_upath: UPath, idx: int
+) -> DetectionCrop:
     # Load crops from the window directory for writing output PNGs.
     # We create two PNGs:
     # - b8.png: just has B8 (panchromatic band).
@@ -558,9 +568,7 @@ def _write_detection_crop(detection: VesselDetection, crop_upath: UPath, idx: in
         images[band + "_sharp"] = np.clip(
             images[band + "_sharp"] * images["B8"] // total, 0, 255
         ).astype(np.uint8)
-    rgb = np.stack(
-        [images["B4_sharp"], images["B3_sharp"], images["B2_sharp"]], axis=2
-    )
+    rgb = np.stack([images["B4_sharp"], images["B3_sharp"], images["B2_sharp"]], axis=2)
 
     rgb_fname = crop_upath / f"{idx}_rgb.png"
     with rgb_fname.open("wb") as f:

--- a/rslp/landsat_vessels/predict_pipeline.py
+++ b/rslp/landsat_vessels/predict_pipeline.py
@@ -34,7 +34,7 @@ from rslp.landsat_vessels.config import (
     LOCAL_FILES_DATASET_CONFIG,
     OUTPUT_LAYER_NAME,
 )
-from rslp.landsat_vessels.prom_metrics import time_operation, TimerOperations
+from rslp.landsat_vessels.prom_metrics import TimerOperations, time_operation
 from rslp.log_utils import get_logger
 from rslp.utils.filter import NearInfraFilter
 from rslp.utils.rslearn import (
@@ -515,6 +515,7 @@ def _build_predictions_and_crops(detections: list[VesselDetection], crop_path: s
 
 @dataclass
 class DetectionCrop:
+    """Dataclass for return type from generating crops."""
     rgb_fname: UPath
     b8_fname: UPath
 

--- a/rslp/landsat_vessels/prom_metrics.py
+++ b/rslp/landsat_vessels/prom_metrics.py
@@ -12,6 +12,7 @@ request_timer = Histogram(
 
 class TimerOperations(StrEnum):
     """Constants for the operations that are timed during inference."""
+
     TotalInferenceTime = "TotalInferenceTime"
     SetupDataset = "SetupDataset"
     MaterializeDataset = "MaterializeDataset"

--- a/rslp/landsat_vessels/prom_metrics.py
+++ b/rslp/landsat_vessels/prom_metrics.py
@@ -1,7 +1,4 @@
-"""
-Definitions for prometheus metrics that are captured during inference to report on performance of the landsat
-detection service.
-"""
+"""Definitions for prometheus metrics that are captured during inference to report on performance of the landsat detection service."""
 
 from enum import StrEnum
 
@@ -14,6 +11,7 @@ request_timer = Histogram(
 
 
 class TimerOperations(StrEnum):
+    """Constants for the operations that are timed during inference."""
     TotalInferenceTime = "TotalInferenceTime"
     SetupDataset = "SetupDataset"
     MaterializeDataset = "MaterializeDataset"
@@ -24,4 +22,5 @@ class TimerOperations(StrEnum):
 
 
 def time_operation(operation: TimerOperations) -> Timer:
+    """Report how long an operation takes to Prometheus Metrics."""
     return request_timer.labels(operation=operation.value).time()

--- a/rslp/landsat_vessels/prom_metrics.py
+++ b/rslp/landsat_vessels/prom_metrics.py
@@ -1,0 +1,27 @@
+"""
+Definitions for prometheus metrics that are captured during inference to report on performance of the landsat
+detection service.
+"""
+
+from enum import StrEnum
+
+from prometheus_client import Histogram
+from prometheus_client.context_managers import Timer
+
+request_timer = Histogram(
+    "landsat_rslearn_timer", "Timers for inference requests", ["operation"]
+)
+
+
+class TimerOperations(StrEnum):
+    TotalInferenceTime = "TotalInferenceTime"
+    SetupDataset = "SetupDataset"
+    MaterializeDataset = "MaterializeDataset"
+    RunModelPredict = "RunModelPredict"
+    GetVesselDetections = "GetVesselDetections"
+    RunClassifier = "RunClassifier"
+    BuildPredictionsAndCrops = "BuildPredictionsAndCrops"
+
+
+def time_operation(operation: TimerOperations) -> Timer:
+    return request_timer.labels(operation=operation.value).time()


### PR DESCRIPTION
This PR: 

* Adds prometheus timer metrics to some points of the landsat prediction pipeline
* Refactors the code that generates image chips slightly to make instrumentation easier. 
* adds a `/metrics` endpoint on the fastapi server for exporting prometheus metrics