### PR TITLE
Hpitelka/landsat rslearn fix

### DIFF
--- a/rslp/landsat_vessels/predict_pipeline.py
+++ b/rslp/landsat_vessels/predict_pipeline.py
@@ -140,7 +140,7 @@ def get_vessel_detections(
 
     # Read the detections.
     layer_dir = window.get_layer_dir(OUTPUT_LAYER_NAME)
-    features = GeojsonVectorFormat().decode_vector(layer_dir, window.bounds)
+    features = GeojsonVectorFormat().decode_vector(layer_dir, window.projection, window.bounds)
     detections: list[VesselDetection] = []
     for feature in features:
         geometry = feature.geometry
@@ -237,7 +237,7 @@ def run_classifier(
     good_detections = []
     for detection, window in zip(detections, windows):
         layer_dir = window.get_layer_dir(OUTPUT_LAYER_NAME)
-        features = GeojsonVectorFormat().decode_vector(layer_dir, window.bounds)
+        features = GeojsonVectorFormat().decode_vector(layer_dir, window.projection, window.bounds)
         category = features[0].properties["label"]
         if category == "correct":
             good_detections.append(detection)
@@ -546,7 +546,7 @@ def _write_detection_crop(
         # raster since anyway we just want to read the whole raster.
         raster_format = GeotiffRasterFormat()
         band_bounds = raster_format.get_raster_bounds(raster_dir)
-        image = raster_format.decode_raster(raster_dir, band_bounds)
+        image = raster_format.decode_raster(raster_dir, crop_window.projection, band_bounds)
         if image.shape[0] != 1:
             raise ValueError(
                 f"expected single-band image for {band} but got {image.shape[0]} bands"

--- a/rslp/landsat_vessels/predict_pipeline.py
+++ b/rslp/landsat_vessels/predict_pipeline.py
@@ -140,7 +140,9 @@ def get_vessel_detections(
 
     # Read the detections.
     layer_dir = window.get_layer_dir(OUTPUT_LAYER_NAME)
-    features = GeojsonVectorFormat().decode_vector(layer_dir, window.projection, window.bounds)
+    features = GeojsonVectorFormat().decode_vector(
+        layer_dir, window.projection, window.bounds
+    )
     detections: list[VesselDetection] = []
     for feature in features:
         geometry = feature.geometry
@@ -237,7 +239,9 @@ def run_classifier(
     good_detections = []
     for detection, window in zip(detections, windows):
         layer_dir = window.get_layer_dir(OUTPUT_LAYER_NAME)
-        features = GeojsonVectorFormat().decode_vector(layer_dir, window.projection, window.bounds)
+        features = GeojsonVectorFormat().decode_vector(
+            layer_dir, window.projection, window.bounds
+        )
         category = features[0].properties["label"]
         if category == "correct":
             good_detections.append(detection)
@@ -546,7 +550,9 @@ def _write_detection_crop(
         # raster since anyway we just want to read the whole raster.
         raster_format = GeotiffRasterFormat()
         band_bounds = raster_format.get_raster_bounds(raster_dir)
-        image = raster_format.decode_raster(raster_dir, crop_window.projection, band_bounds)
+        image = raster_format.decode_raster(
+            raster_dir, crop_window.projection, band_bounds
+        )
         if image.shape[0] != 1:
             raise ValueError(
                 f"expected single-band image for {band} but got {image.shape[0]} bands"


### PR DESCRIPTION
In [this change](https://github.com/allenai/rslearn/commit/9cca4e94c1c6cf3fd9c68665c1987472d42fe9e5#diff-c2e1d03e68b1bf0d3875675241ae9f93f421c88d5c37e3d516f36d6bab573c38L43) in rslearn 3 weeks ago, @favyen2 updated the `decode_vector` and `decode_raster` methods to require a third argument, Projection.    

Since rolling out the updated landsat model yesterday we've started getting all errors of: 

```
Traceback (most recent call last):
  File "/opt/rslearn_projects/rslp/landsat_vessels/api_main.py", line 187, in get_detections
    json_data = predict_pipeline(
                ^^^^^^^^^^^^^^^^^
  File "/opt/rslearn_projects/rslp/landsat_vessels/predict_pipeline.py", line 455, in predict_pipeline
    detections = get_vessel_detections(ds_path, scene_data)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/rslearn_projects/rslp/landsat_vessels/predict_pipeline.py", line 143, in get_vessel_detections
    features = GeojsonVectorFormat().decode_vector(layer_dir, window.bounds)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: GeojsonVectorFormat.decode_vector() missing 1 required positional argument: 'bounds'
```


I think this fixes that. 