### PR TITLE
Add code for launching Helios fine-tuning evaluations.

### DIFF
--- a/.github/workflows/forest_loss_driver_prediction.yaml
+++ b/.github/workflows/forest_loss_driver_prediction.yaml
@@ -76,11 +76,11 @@ jobs:
             "${DOCKER_SERVICE_NAME}" python -m rslp.main \
             common \
             beaker_launcher \
-            "${RSLP_PROJECT}" \
-            "${RSLP_WORKFLOW}" \
-            "${EXTRA_ARGS}" \
-            "${BEAKER_IMAGE_FULL_NAME}" \
-            "${CLUSTERS}" \
+            --project "${RSLP_PROJECT}" \
+            --workflow "${RSLP_WORKFLOW}" \
+            --extra_args "${EXTRA_ARGS}" \
+            --image "${BEAKER_IMAGE_FULL_NAME}" \
+            --clusters "${CLUSTERS}" \
             --gpu_count 1 \
             --preemptible true \
             --weka_mounts "${WEKA_MOUNTS}" \

--- a/ai2_docs/README.md
+++ b/ai2_docs/README.md
@@ -11,7 +11,7 @@ Tooling
 The additional tooling comes into play when training and deploying models. This is an
 outline of the steps the tooling takes care of when training models:
 
-1. User runs e.g. `python -m rslp.launch_beaker --config_path path/to/config.yaml`.
+1. User runs e.g. `python -m rslp.main common beaker_train --config_path path/to/config.yaml`.
 2. Launcher uploads the code to a canonical path on Google Cloud Storage (GCS), based
    on the project ID and experiment ID specified in `config.yaml`.
 3. Launcher then starts a job, in this case on Beaker, to train the model.
@@ -42,7 +42,7 @@ You will also need to setup GCP credentials that have access to this bucket.
 
 Training additionally depends on credentials for W&B. If you train directly using
 `rslp.rslearn_main`, then you will need to setup these credentials. If you use a
-launcher like `rslp.launch_beaker`, then it isn't needed since the credentials are
+launcher like `rslp.main common beaker_train`, then it isn't needed since the credentials are
 already configured as secrets on the platform, but you would need to setup your Beaker
 or other platform credentials to be able to launch the jobs.
 
@@ -66,16 +66,15 @@ Execute a data processing pipeline:
 
     python -m rslp.main maldives_ecosystem_mapping data --dp_config.workers 32
 
-Launch training on Beaker:
-
-    python -m rslp.main maldives_ecosystem_mapping train_maxar
-
 Manually train locally:
 
     python -m rslp.rslearn_main model fit --config_path data/maldives_ecosystem_mapping/config.yaml
 
+To launch training on Beaker, first build and push a Docker image:
 
-Projects
---------
+    docker build -t rslp .
+    beaker image create --name rslp rslp
 
-- [Forest Loss Driver](rslp/forest_loss_driver/README.md)
+Launch training on Beaker:
+
+    python -m rslp.main common beaker_train --config_path data/maldives_ecosystem_mapping/config_planetscope_plus_sentinel2.yaml --image_name [YOUR_BEAKER_USERNAME]/rslp --cluster '["ai2/jupiter-cirrascale-2"]'

--- a/data/helios/eurosat/finetune.yaml
+++ b/data/helios/eurosat/finetune.yaml
@@ -1,0 +1,96 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "{CHECKPOINT_PATH}"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          eurosat:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/eurosat/rslearn_dataset/
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eurosat:
+            class_path: rslearn.train.tasks.classification.ClassificationTask
+            init_args:
+              property_name: "category"
+              classes: ["AnnualCrop", "Forest", "HerbaceousVegetation", "Highway", "Industrial", "Pasture", "PermanentCrop", "Residential", "River", "SeaLake"]
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          eurosat:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      tags:
+        split: "train"
+    val_config:
+      tags:
+        split: "val"
+    test_config:
+      tags:
+        split: "val"
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_loss
+        mode: min
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: placeholder
+        output_layer: output
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 2
+rslp_project: helios_finetuning
+rslp_experiment: placeholder

--- a/data/helios/eurosat/frozen.yaml
+++ b/data/helios/eurosat/frozen.yaml
@@ -1,0 +1,95 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "{CHECKPOINT_PATH}"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          eurosat:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/eurosat/rslearn_dataset/
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eurosat:
+            class_path: rslearn.train.tasks.classification.ClassificationTask
+            init_args:
+              property_name: "category"
+              classes: ["AnnualCrop", "Forest", "HerbaceousVegetation", "Highway", "Industrial", "Pasture", "PermanentCrop", "Residential", "River", "SeaLake"]
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          eurosat:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      tags:
+        split: "train"
+    val_config:
+      tags:
+        split: "val"
+    test_config:
+      tags:
+        split: "val"
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_loss
+        mode: min
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: placeholder
+        output_layer: output
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+rslp_project: helios_finetuning
+rslp_experiment: placeholder

--- a/data/helios/eurosat/frozen.yaml
+++ b/data/helios/eurosat/frozen.yaml
@@ -10,12 +10,12 @@ model:
               checkpoint_path: "{CHECKPOINT_PATH}"
               selector: ["encoder"]
               forward_kwargs:
-                patch_size: 8
+                patch_size: {PATCH_SIZE}
         decoders:
           eurosat:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 10
                 num_conv_layers: 1
                 num_fc_layers: 2

--- a/data/helios/eurosat/random.yaml
+++ b/data/helios/eurosat/random.yaml
@@ -11,6 +11,7 @@ model:
               selector: ["encoder"]
               forward_kwargs:
                 patch_size: {PATCH_SIZE}
+              random_initialization: true
         decoders:
           eurosat:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
@@ -88,9 +89,5 @@ trainer:
       init_args:
         path: placeholder
         output_layer: output
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
-        unfreeze_at_epoch: 2
 rslp_project: helios_finetuning
 rslp_experiment: placeholder

--- a/data/helios/satlas_marine_infra/finetune.yaml
+++ b/data/helios/satlas_marine_infra/finetune.yaml
@@ -7,15 +7,15 @@ model:
         encoder:
           - class_path: rslp.helios.model.Helios
             init_args:
-              checkpoint_path: "CHECKPOINT_PATH"
+              checkpoint_path: "{CHECKPOINT_PATH}"
               selector: ["encoder"]
               forward_kwargs:
-                patch_size: 8
+                patch_size: {PATCH_SIZE}
         decoders:
           detect:
             - class_path: rslearn.models.conv.Conv
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 192
                 kernel_size: 3
             - class_path: rslearn.models.conv.Conv

--- a/data/helios/satlas_marine_infra/finetune.yaml
+++ b/data/helios/satlas_marine_infra/finetune.yaml
@@ -26,7 +26,7 @@ model:
                 activation:
                   class_path: torch.nn.LayerNorm
                   init_args:
-                    normalized_shape: [192, 32, 32]
+                    normalized_shape: [192, {256/PATCH_SIZE}, {256/PATCH_SIZE}]
             - class_path: rslearn.models.conv.Conv
               init_args:
                 in_channels: 192
@@ -41,7 +41,7 @@ model:
                   class_path: torch.nn.Identity
             - class_path: rslearn.models.faster_rcnn.FasterRCNN
               init_args:
-                downsample_factors: [8]
+                downsample_factors: [{PATCH_SIZE}]
                 num_channels: 192
                 num_classes: 3
                 anchor_sizes: [[32]]

--- a/data/helios/satlas_marine_infra/finetune.yaml
+++ b/data/helios/satlas_marine_infra/finetune.yaml
@@ -1,0 +1,152 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "CHECKPOINT_PATH"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          detect:
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 768
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.LayerNorm
+                  init_args:
+                    normalized_shape: [192, 32, 32]
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.Identity
+            - class_path: rslearn.models.faster_rcnn.FasterRCNN
+              init_args:
+                downsample_factors: [8]
+                num_channels: 192
+                num_classes: 3
+                anchor_sizes: [[32]]
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/marine_infra/dataset_v1/20241210/
+    inputs:
+      image:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          detect:
+            class_path: rslp.satlas.train.MarineInfraTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "platform", "turbine"]
+              box_size: 15
+              remap_values: [[0, 0.25], [0, 255]]
+              image_bands: [2, 1, 0]
+              exclude_by_center: true
+              enable_map_metric: true
+              enable_f1_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95], [0.1], [0.2], [0.3], [0.4], [0.5], [0.6], [0.7], [0.8], [0.9]]
+              skip_unknown_categories: true
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          detect:
+            targets: "targets"
+    batch_size: 4
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              image: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      patch_size: 256
+      tags:
+        split: train
+        nonempty: "yes"
+    val_config:
+      patch_size: 256
+      tags:
+        split: val
+        nonempty: "yes"
+    test_config:
+      patch_size: 256
+      tags:
+        split: val
+        nonempty: "yes"
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: placeholder
+        output_layer: output
+        selector: ["detect"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_detect/mAP
+        mode: max
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 2
+rslp_project: helios_finetuning
+rslp_experiment: placeholder

--- a/data/helios/satlas_marine_infra/random.yaml
+++ b/data/helios/satlas_marine_infra/random.yaml
@@ -27,7 +27,7 @@ model:
                 activation:
                   class_path: torch.nn.LayerNorm
                   init_args:
-                    normalized_shape: [192, 32, 32]
+                    normalized_shape: [192, {256/PATCH_SIZE}, {256/PATCH_SIZE}]
             - class_path: rslearn.models.conv.Conv
               init_args:
                 in_channels: 192
@@ -42,7 +42,7 @@ model:
                   class_path: torch.nn.Identity
             - class_path: rslearn.models.faster_rcnn.FasterRCNN
               init_args:
-                downsample_factors: [8]
+                downsample_factors: [{PATCH_SIZE}]
                 num_channels: 192
                 num_classes: 3
                 anchor_sizes: [[32]]

--- a/data/helios/satlas_marine_infra/random.yaml
+++ b/data/helios/satlas_marine_infra/random.yaml
@@ -11,6 +11,7 @@ model:
               selector: ["encoder"]
               forward_kwargs:
                 patch_size: {PATCH_SIZE}
+              random_initialization: true
         decoders:
           detect:
             - class_path: rslearn.models.conv.Conv
@@ -49,12 +50,12 @@ model:
     plateau: true
     plateau_factor: 0.2
     plateau_patience: 2
-    plateau_min_lr: 1e-6
+    plateau_min_lr: 0
     plateau_cooldown: 10
 data:
   class_path: rslearn.train.data_module.RslearnDataModule
   init_args:
-    path: gs://rslearn-eai/datasets/sentinel2_vessels/dataset_v1/20250213/
+    path: gs://rslearn-eai/datasets/marine_infra/dataset_v1/20241210/
     inputs:
       image:
         data_type: "raster"
@@ -67,7 +68,7 @@ data:
         layers: ["mask"]
         bands: ["mask"]
         passthrough: true
-        dtype: INT32
+        dtype: FLOAT32
         is_target: true
       targets:
         data_type: "vector"
@@ -78,17 +79,18 @@ data:
       init_args:
         tasks:
           detect:
-            class_path: rslearn.train.tasks.detection.DetectionTask
+            class_path: rslp.satlas.train.MarineInfraTask
             init_args:
               property_name: "category"
-              classes: ["unknown", "vessel"]
+              classes: ["unknown", "platform", "turbine"]
               box_size: 15
-              remap_values: [[0, 1], [0, 255]]
+              remap_values: [[0, 0.25], [0, 255]]
+              image_bands: [2, 1, 0]
               exclude_by_center: true
-              score_threshold: 0.8
               enable_map_metric: true
               enable_f1_metric: true
               f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95], [0.1], [0.2], [0.3], [0.4], [0.5], [0.6], [0.7], [0.8], [0.9]]
+              skip_unknown_categories: true
               f1_metric_kwargs:
                 cmp_mode: "distance"
                 cmp_threshold: 15
@@ -96,7 +98,7 @@ data:
         input_mapping:
           detect:
             targets: "targets"
-    batch_size: 8
+    batch_size: 4
     num_workers: 32
     default_config:
       transforms:
@@ -113,13 +115,19 @@ data:
               sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
     train_config:
       patch_size: 256
-      groups: ["sargassum_train", "split2", "split3", "split4", "split5", "split6", "train", "train-bg", "train2", "train3"]
+      tags:
+        split: train
+        nonempty: "yes"
     val_config:
       patch_size: 256
-      groups: ["sargassum_val", "split1", "split7"]
+      tags:
+        split: val
+        nonempty: "yes"
     test_config:
       patch_size: 256
-      groups: ["sargassum_val", "split1", "split7"]
+      tags:
+        split: val
+        nonempty: "yes"
 trainer:
   max_epochs: 500
   callbacks:
@@ -128,25 +136,14 @@ trainer:
         logging_interval: "epoch"
     - class_path: rslearn.train.prediction_writer.RslearnWriter
       init_args:
-        path: gs://rslearn-eai/datasets/sentinel2_vessels/dataset_v1/20250213/
+        path: placeholder
         output_layer: output
         selector: ["detect"]
-        merger:
-          class_path: rslp.utils.nms.NMSDistanceMerger
-          init_args:
-            grid_size: 64
-            distance_threshold: 10
-            property_name: "category"  # same as task.property_name
-            class_agnostic: false
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         save_top_k: 1
         save_last: true
         monitor: val_detect/mAP
         mode: max
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
-        unfreeze_at_epoch: 2
 rslp_project: helios_finetuning
 rslp_experiment: placeholder

--- a/data/helios/satlas_wind_turbine/finetune.yaml
+++ b/data/helios/satlas_wind_turbine/finetune.yaml
@@ -26,7 +26,7 @@ model:
                 activation:
                   class_path: torch.nn.LayerNorm
                   init_args:
-                    normalized_shape: [192, 32, 32]
+                    normalized_shape: [192, {256/PATCH_SIZE}, {256/PATCH_SIZE}]
             - class_path: rslearn.models.conv.Conv
               init_args:
                 in_channels: 192
@@ -41,7 +41,7 @@ model:
                   class_path: torch.nn.Identity
             - class_path: rslearn.models.faster_rcnn.FasterRCNN
               init_args:
-                downsample_factors: [8]
+                downsample_factors: [{PATCH_SIZE}]
                 num_channels: 192
                 num_classes: 3
                 anchor_sizes: [[32]]

--- a/data/helios/satlas_wind_turbine/finetune.yaml
+++ b/data/helios/satlas_wind_turbine/finetune.yaml
@@ -1,0 +1,149 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "{CHECKPOINT_PATH}"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          detect:
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 768
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.LayerNorm
+                  init_args:
+                    normalized_shape: [192, 32, 32]
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.Identity
+            - class_path: rslearn.models.faster_rcnn.FasterRCNN
+              init_args:
+                downsample_factors: [8]
+                num_channels: 192
+                num_classes: 3
+                anchor_sizes: [[32]]
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/wind_turbine/dataset_v1/20241002/
+    inputs:
+      image:
+        data_type: "raster"
+        layers: ["sentinel2_a"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          detect:
+            class_path: rslearn.train.tasks.detection.DetectionTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "turbine"]
+              box_size: 15
+              remap_values: [[0, 1], [0, 255]]
+              exclude_by_center: true
+              enable_map_metric: true
+              enable_f1_metric: true
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          detect:
+            targets: "targets"
+    batch_size: 4
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              image: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      patch_size: 256
+      groups: ["label", "naip"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 256
+      groups: ["label", "naip"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 256
+      groups: ["label", "naip"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: placeholder
+        output_layer: output
+        selector: ["detect"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_detect/mAP
+        mode: max
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 2
+rslp_project: helios_finetuning
+rslp_experiment: placeholder

--- a/data/helios/satlas_wind_turbine/finetune.yaml
+++ b/data/helios/satlas_wind_turbine/finetune.yaml
@@ -10,12 +10,12 @@ model:
               checkpoint_path: "{CHECKPOINT_PATH}"
               selector: ["encoder"]
               forward_kwargs:
-                patch_size: 8
+                patch_size: {PATCH_SIZE}
         decoders:
           detect:
             - class_path: rslearn.models.conv.Conv
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 192
                 kernel_size: 3
             - class_path: rslearn.models.conv.Conv

--- a/data/helios/satlas_wind_turbine/random.yaml
+++ b/data/helios/satlas_wind_turbine/random.yaml
@@ -11,6 +11,7 @@ model:
               selector: ["encoder"]
               forward_kwargs:
                 patch_size: {PATCH_SIZE}
+              random_initialization: true
         decoders:
           detect:
             - class_path: rslearn.models.conv.Conv
@@ -49,16 +50,16 @@ model:
     plateau: true
     plateau_factor: 0.2
     plateau_patience: 2
-    plateau_min_lr: 1e-6
+    plateau_min_lr: 0
     plateau_cooldown: 10
 data:
   class_path: rslearn.train.data_module.RslearnDataModule
   init_args:
-    path: gs://rslearn-eai/datasets/sentinel2_vessels/dataset_v1/20250213/
+    path: gs://rslearn-eai/datasets/wind_turbine/dataset_v1/20241002/
     inputs:
       image:
         data_type: "raster"
-        layers: ["sentinel2"]
+        layers: ["sentinel2_a"]
         bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
         passthrough: true
         dtype: FLOAT32
@@ -67,7 +68,7 @@ data:
         layers: ["mask"]
         bands: ["mask"]
         passthrough: true
-        dtype: INT32
+        dtype: FLOAT32
         is_target: true
       targets:
         data_type: "vector"
@@ -81,14 +82,12 @@ data:
             class_path: rslearn.train.tasks.detection.DetectionTask
             init_args:
               property_name: "category"
-              classes: ["unknown", "vessel"]
+              classes: ["unknown", "turbine"]
               box_size: 15
               remap_values: [[0, 1], [0, 255]]
               exclude_by_center: true
-              score_threshold: 0.8
               enable_map_metric: true
               enable_f1_metric: true
-              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95], [0.1], [0.2], [0.3], [0.4], [0.5], [0.6], [0.7], [0.8], [0.9]]
               f1_metric_kwargs:
                 cmp_mode: "distance"
                 cmp_threshold: 15
@@ -96,7 +95,7 @@ data:
         input_mapping:
           detect:
             targets: "targets"
-    batch_size: 8
+    batch_size: 4
     num_workers: 32
     default_config:
       transforms:
@@ -113,13 +112,19 @@ data:
               sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
     train_config:
       patch_size: 256
-      groups: ["sargassum_train", "split2", "split3", "split4", "split5", "split6", "train", "train-bg", "train2", "train3"]
+      groups: ["label", "naip"]
+      tags:
+        split: train
     val_config:
       patch_size: 256
-      groups: ["sargassum_val", "split1", "split7"]
+      groups: ["label", "naip"]
+      tags:
+        split: val
     test_config:
       patch_size: 256
-      groups: ["sargassum_val", "split1", "split7"]
+      groups: ["label", "naip"]
+      tags:
+        split: val
 trainer:
   max_epochs: 500
   callbacks:
@@ -128,25 +133,14 @@ trainer:
         logging_interval: "epoch"
     - class_path: rslearn.train.prediction_writer.RslearnWriter
       init_args:
-        path: gs://rslearn-eai/datasets/sentinel2_vessels/dataset_v1/20250213/
+        path: placeholder
         output_layer: output
         selector: ["detect"]
-        merger:
-          class_path: rslp.utils.nms.NMSDistanceMerger
-          init_args:
-            grid_size: 64
-            distance_threshold: 10
-            property_name: "category"  # same as task.property_name
-            class_agnostic: false
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         save_top_k: 1
         save_last: true
         monitor: val_detect/mAP
         mode: max
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
-        unfreeze_at_epoch: 2
 rslp_project: helios_finetuning
 rslp_experiment: placeholder

--- a/data/helios/satlas_wind_turbine/random.yaml
+++ b/data/helios/satlas_wind_turbine/random.yaml
@@ -27,7 +27,7 @@ model:
                 activation:
                   class_path: torch.nn.LayerNorm
                   init_args:
-                    normalized_shape: [192, 32, 32]
+                    normalized_shape: [192, {256/PATCH_SIZE}, {256/PATCH_SIZE}]
             - class_path: rslearn.models.conv.Conv
               init_args:
                 in_channels: 192
@@ -42,7 +42,7 @@ model:
                   class_path: torch.nn.Identity
             - class_path: rslearn.models.faster_rcnn.FasterRCNN
               init_args:
-                downsample_factors: [8]
+                downsample_factors: [{PATCH_SIZE}]
                 num_channels: 192
                 num_classes: 3
                 anchor_sizes: [[32]]

--- a/data/helios/sentinel2_vessel_attribute/finetune.yaml
+++ b/data/helios/sentinel2_vessel_attribute/finetune.yaml
@@ -10,12 +10,12 @@ model:
               checkpoint_path: "{CHECKPOINT_PATH}"
               selector: ["encoder"]
               forward_kwargs:
-                patch_size: 8
+                patch_size: {PATCH_SIZE}
         decoders:
           length:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 1
                 num_conv_layers: 1
                 num_fc_layers: 2
@@ -23,7 +23,7 @@ model:
           width:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 1
                 num_conv_layers: 1
                 num_fc_layers: 2
@@ -31,7 +31,7 @@ model:
           speed:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 1
                 num_conv_layers: 1
                 num_fc_layers: 2
@@ -39,7 +39,7 @@ model:
           heading_x:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 1
                 num_conv_layers: 1
                 num_fc_layers: 2
@@ -47,7 +47,7 @@ model:
           heading_y:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 1
                 num_conv_layers: 1
                 num_fc_layers: 2
@@ -55,7 +55,7 @@ model:
           ship_type:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
               init_args:
-                in_channels: 768
+                in_channels: {ENCODER_EMBEDDING_SIZE}
                 out_channels: 9
                 num_conv_layers: 1
                 num_fc_layers: 2

--- a/data/helios/sentinel2_vessel_attribute/finetune.yaml
+++ b/data/helios/sentinel2_vessel_attribute/finetune.yaml
@@ -1,0 +1,189 @@
+model:
+  class_path: rslp.sentinel2_vessel_attribute.train.VesselAttributeLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "{CHECKPOINT_PATH}"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          length:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          width:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          speed:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          heading_x:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          heading_y:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          ship_type:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 9
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+      info:
+        data_type: "vector"
+        layers: ["info"]
+        is_target: true
+    task:
+      class_path: rslp.sentinel2_vessel_attribute.train.VesselAttributeMultiTask
+      init_args:
+        length_buckets: [10, 20, 30, 50, 75, 100, 150, 200]
+        width_buckets: [5, 10, 20]
+        speed_buckets: [2, 4, 8]
+        tasks:
+          length:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "length"
+              allow_invalid: true
+              scale_factor: 0.01
+              metric_mode: l1
+          width:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "width"
+              allow_invalid: true
+              scale_factor: 0.01
+              metric_mode: l1
+          speed:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "sog"
+              allow_invalid: true
+              scale_factor: 0.01
+              metric_mode: l1
+          heading_x:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "cog_x"
+              allow_invalid: true
+              metric_mode: l1
+          heading_y:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "cog_y"
+              allow_invalid: true
+              metric_mode: l1
+          ship_type:
+            class_path: rslearn.train.tasks.classification.ClassificationTask
+            init_args:
+              property_name: "type"
+              allow_invalid: true
+              classes: ["cargo", "tanker", "passenger", "service", "tug", "pleasure", "fishing", "enforcement", "sar"]
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          length:
+            info: "targets"
+          width:
+            info: "targets"
+          speed:
+            info: "targets"
+          heading_x:
+            info: "targets"
+          heading_y:
+            info: "targets"
+          ship_type:
+            info: "targets"
+    batch_size: 16
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      tags:
+        split: "train"
+      groups: ["detections_bigtable"]
+    val_config:
+      tags:
+        split: "val"
+      groups: ["detections_bigtable"]
+    test_config:
+      tags:
+        split: "val"
+      groups: ["detections_bigtable"]
+    predict_config:
+      groups: ["attribute_predict"]
+      skip_targets: true
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_loss
+        mode: min
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: placeholder
+        output_layer: output
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 1
+rslp_project: helios_finetuning
+rslp_experiment: placeholder

--- a/data/helios/sentinel2_vessel_attribute/frozen.yaml
+++ b/data/helios/sentinel2_vessel_attribute/frozen.yaml
@@ -1,0 +1,188 @@
+model:
+  class_path: rslp.sentinel2_vessel_attribute.train.VesselAttributeLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "{CHECKPOINT_PATH}"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          length:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          width:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          speed:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          heading_x:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          heading_y:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.regression.RegressionHead
+          ship_type:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 768
+                out_channels: 9
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+      info:
+        data_type: "vector"
+        layers: ["info"]
+        is_target: true
+    task:
+      class_path: rslp.sentinel2_vessel_attribute.train.VesselAttributeMultiTask
+      init_args:
+        length_buckets: [10, 20, 30, 50, 75, 100, 150, 200]
+        width_buckets: [5, 10, 20]
+        speed_buckets: [2, 4, 8]
+        tasks:
+          length:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "length"
+              allow_invalid: true
+              scale_factor: 0.01
+              metric_mode: l1
+          width:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "width"
+              allow_invalid: true
+              scale_factor: 0.01
+              metric_mode: l1
+          speed:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "sog"
+              allow_invalid: true
+              scale_factor: 0.01
+              metric_mode: l1
+          heading_x:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "cog_x"
+              allow_invalid: true
+              metric_mode: l1
+          heading_y:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "cog_y"
+              allow_invalid: true
+              metric_mode: l1
+          ship_type:
+            class_path: rslearn.train.tasks.classification.ClassificationTask
+            init_args:
+              property_name: "type"
+              allow_invalid: true
+              classes: ["cargo", "tanker", "passenger", "service", "tug", "pleasure", "fishing", "enforcement", "sar"]
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          length:
+            info: "targets"
+          width:
+            info: "targets"
+          speed:
+            info: "targets"
+          heading_x:
+            info: "targets"
+          heading_y:
+            info: "targets"
+          ship_type:
+            info: "targets"
+    batch_size: 16
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      tags:
+        split: "train"
+      groups: ["detections_bigtable"]
+    val_config:
+      tags:
+        split: "val"
+      groups: ["detections_bigtable"]
+    test_config:
+      tags:
+        split: "val"
+      groups: ["detections_bigtable"]
+    predict_config:
+      groups: ["attribute_predict"]
+      skip_targets: true
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_loss
+        mode: min
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: placeholder
+        output_layer: output
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+rslp_project: helios_finetuning
+rslp_experiment: placeholder

--- a/data/helios/sentinel2_vessel_attribute/random.yaml
+++ b/data/helios/sentinel2_vessel_attribute/random.yaml
@@ -11,6 +11,7 @@ model:
               selector: ["encoder"]
               forward_kwargs:
                 patch_size: {PATCH_SIZE}
+              random_initialization: true
         decoders:
           length:
             - class_path: rslearn.models.pooling_decoder.PoolingDecoder
@@ -181,8 +182,5 @@ trainer:
       init_args:
         path: placeholder
         output_layer: output
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
 rslp_project: helios_finetuning
 rslp_experiment: placeholder

--- a/data/helios/sentinel2_vessels/finetune.yaml
+++ b/data/helios/sentinel2_vessels/finetune.yaml
@@ -26,7 +26,7 @@ model:
                 activation:
                   class_path: torch.nn.LayerNorm
                   init_args:
-                    normalized_shape: [192, 32, 32]
+                    normalized_shape: [192, {256/PATCH_SIZE}, {256/PATCH_SIZE}]
             - class_path: rslearn.models.conv.Conv
               init_args:
                 in_channels: 192
@@ -41,7 +41,7 @@ model:
                   class_path: torch.nn.Identity
             - class_path: rslearn.models.faster_rcnn.FasterRCNN
               init_args:
-                downsample_factors: [8]
+                downsample_factors: [{PATCH_SIZE}]
                 num_channels: 192
                 num_classes: 3
                 anchor_sizes: [[32]]

--- a/data/helios/sentinel2_vessels/finetune.yaml
+++ b/data/helios/sentinel2_vessels/finetune.yaml
@@ -1,0 +1,152 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "{CHECKPOINT_PATH}"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          detect:
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 768
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.LayerNorm
+                  init_args:
+                    normalized_shape: [192, 32, 32]
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.Identity
+            - class_path: rslearn.models.faster_rcnn.FasterRCNN
+              init_args:
+                downsample_factors: [8]
+                num_channels: 192
+                num_classes: 3
+                anchor_sizes: [[32]]
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 1e-6
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/sentinel2_vessels/dataset_v1/20250213/
+    inputs:
+      image:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: INT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          detect:
+            class_path: rslearn.train.tasks.detection.DetectionTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "vessel"]
+              box_size: 15
+              remap_values: [[0, 1], [0, 255]]
+              exclude_by_center: true
+              score_threshold: 0.8
+              enable_map_metric: true
+              enable_f1_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95], [0.1], [0.2], [0.3], [0.4], [0.5], [0.6], [0.7], [0.8], [0.9]]
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          detect:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              image: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      patch_size: 256
+      groups: ["sargassum_train", "split2", "split3", "split4", "split5", "split6", "train", "train-bg", "train2", "train3"]
+    val_config:
+      patch_size: 256
+      groups: ["sargassum_val", "split1", "split7"]
+    test_config:
+      patch_size: 256
+      groups: ["sargassum_val", "split1", "split7"]
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: gs://rslearn-eai/datasets/sentinel2_vessels/dataset_v1/20250213/
+        output_layer: output
+        selector: ["detect"]
+        merger:
+          class_path: rslp.utils.nms.NMSDistanceMerger
+          init_args:
+            grid_size: 64
+            distance_threshold: 10
+            property_name: "category"  # same as task.property_name
+            class_agnostic: false
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_detect/mAP
+        mode: max
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 2
+rslp_project: helios_finetuning
+rslp_experiment: placeholder

--- a/data/helios/sentinel2_vessels/random.yaml
+++ b/data/helios/sentinel2_vessels/random.yaml
@@ -11,6 +11,7 @@ model:
               selector: ["encoder"]
               forward_kwargs:
                 patch_size: {PATCH_SIZE}
+              random_initialization: true
         decoders:
           detect:
             - class_path: rslearn.models.conv.Conv
@@ -144,9 +145,5 @@ trainer:
         save_last: true
         monitor: val_detect/mAP
         mode: max
-    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
-      init_args:
-        module_selector: ["model", "encoder", 0]
-        unfreeze_at_epoch: 2
 rslp_project: helios_finetuning
 rslp_experiment: placeholder

--- a/data/helios/sentinel2_vessels/random.yaml
+++ b/data/helios/sentinel2_vessels/random.yaml
@@ -27,7 +27,7 @@ model:
                 activation:
                   class_path: torch.nn.LayerNorm
                   init_args:
-                    normalized_shape: [192, 32, 32]
+                    normalized_shape: [192, {256/PATCH_SIZE}, {256/PATCH_SIZE}]
             - class_path: rslearn.models.conv.Conv
               init_args:
                 in_channels: 192
@@ -42,7 +42,7 @@ model:
                   class_path: torch.nn.Identity
             - class_path: rslearn.models.faster_rcnn.FasterRCNN
               init_args:
-                downsample_factors: [8]
+                downsample_factors: [{PATCH_SIZE}]
                 num_channels: 192
                 num_classes: 3
                 anchor_sizes: [[32]]

--- a/docs/satlas_marine_infra.md
+++ b/docs/satlas_marine_infra.md
@@ -61,7 +61,7 @@ time range, it should be a seven month range to give enough options to pick the 
 30-day mosaics, note that the timestamps are ISO 8601 formatted.
 
     mkdir out_dir
-    python -m rslp.main satlas predict MARINE_INFRA '{"crs": "EPSG:32651", "x_resolution": 10, "y_resolution": -10}' '[18432, -268288, 22528, -264192]' '["2024-01-01T00:00:00+00:00", "2024-08-01T00:00:00+00:00"]' out_dir/ scratch_dir/ --use_rtree_index false
+    python -m rslp.main satlas predict --application MARINE_INFRA --projection_json '{"crs": "EPSG:32651", "x_resolution": 10, "y_resolution": -10}' --bounds '[18432, -268288, 22528, -264192]' --time_range '["2024-01-01T00:00:00+00:00", "2024-08-01T00:00:00+00:00"]' --out_path out_dir/ --scratch_path scratch_dir/ --use_rtree_index false
 
 You may need to delete the "scratch_dir" directory if it exists already. This is used
 to store a temporary rslearn dataset for ingesting the Sentinel-2 input images.
@@ -71,7 +71,7 @@ longitude/latitude coordinates using this script (which can also be used to merg
 multiple GeoJSONs produced by the prediction pipeline):
 
     mkdir merged_dir
-    python -m rslp.main satlas merge_points MARINE_INFRA 2024-01 out_dir/ merged_dir/
+    python -m rslp.main satlas merge_points --application MARINE_INFRA --label 2024-01 --predict_path out_dir/ --merged_path merged_dir/
 
 Now you can open the GeoJSON to view predicted positions of marine infrastructure, e.g.
 in qgis:

--- a/docs/sentinel2_vessels.md
+++ b/docs/sentinel2_vessels.md
@@ -31,7 +31,7 @@ automatically downloads the scene images from a
 
     mkdir output_crops
     mkdir scratch_dir
-    python -m rslp.main sentinel2_vessels predict '[{"scene_id": "S2A_MSIL1C_20180904T110621_N0206_R137_T30UYD_20180904T133425", "geojson_path": "out.geojson", "crop_path": "output_crops/"}]' scratch_dir/
+    python -m rslp.main sentinel2_vessels predict --tasks '[{"scene_id": "S2A_MSIL1C_20180904T110621_N0206_R137_T30UYD_20180904T133425", "geojson_path": "out.geojson", "crop_path": "output_crops/"}]' --scratch_path scratch_dir/
     qgis out.geojson scratch_dir/windows/default/default/layers/sentinel2/R_G_B/geotiff.tif
 
 Then, `out.geojson` will contain a GeoJSON of detected ships while `output_crops` will

--- a/helios.Dockerfile
+++ b/helios.Dockerfile
@@ -1,0 +1,16 @@
+FROM pytorch/pytorch:2.5.0-cuda11.8-cudnn9-runtime@sha256:d15e9803095e462e351f097fb1f5e7cdaa4f5e855d7ff6d6f36ec4c2aa2938ea
+
+RUN apt update
+RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget
+
+# Install rslearn and helios (need to be in local directory).
+COPY ./rslearn /opt/rslearn
+COPY ./helios /opt/helios
+COPY requirements.txt /opt/rslearn_projects/requirements.txt
+RUN pip install --no-cache-dir --upgrade /opt/rslearn[extra] /opt/helios -r /opt/rslearn_projects/requirements.txt
+
+# Copy rslearn_projects and install it too.
+COPY . /opt/rslearn_projects/
+RUN pip install --no-cache-dir /opt/rslearn_projects
+
+WORKDIR /opt/rslearn_projects

--- a/one_off_projects/__init__.py
+++ b/one_off_projects/__init__.py
@@ -1,0 +1,1 @@
+"""Projects that are one-time and don't need to be maintained."""

--- a/rslp/common/README.md
+++ b/rslp/common/README.md
@@ -20,11 +20,11 @@ See `satlas/write_jobs.py` for an example of this.
 
 Then you can launch the worker. To test on one machine:
 
-    python -m rslp.main common worker skylight-proto-1 rslp-job-queue-YOURNAME-sub
+    python -m rslp.main common worker --project_id skylight-proto-1 --subscription_id rslp-job-queue-YOURNAME-sub
 
 And to launch 100 workers on Beaker:
 
-    python -m rslp.main common launch BEAKER_IMAGE_NAME skylight-proto-1 rslp-job-queue-YOURNAME-sub 100 --gpus 1 --shared_memory 256GiB --cluster '["ai2/jupiter-cirrascale-2"]'
+    python -m rslp.main common launch --image_name BEAKER_IMAGE_NAME --project_id skylight-proto-1 --subscription_id rslp-job-queue-YOURNAME-sub --num_workers 100 --gpus 1 --shared_memory 256GiB --cluster '["ai2/jupiter-cirrascale-2"]'
 
 
 Beaker Launcher

--- a/rslp/common/__init__.py
+++ b/rslp/common/__init__.py
@@ -1,6 +1,7 @@
 """Pipelines common across projects."""
 
 from .beaker_launcher import launch_job
+from .beaker_train import beaker_train
 from .worker import launch_workers, worker_pipeline
 from .write_file import write_file
 
@@ -8,5 +9,6 @@ workflows = {
     "worker": worker_pipeline,
     "launch": launch_workers,
     "beaker_launcher": launch_job,
+    "beaker_train": beaker_train,
     "write_file": write_file,
 }

--- a/rslp/common/beaker_launcher.py
+++ b/rslp/common/beaker_launcher.py
@@ -1,16 +1,16 @@
 """Launch a Beaker job that executes one or more rslp workflows."""
 
 import uuid
-from dataclasses import dataclass
 from datetime import datetime
 
-from beaker import Beaker, DataMount, DataSource, EnvVar, ExperimentSpec, ImageSource
+from beaker import Beaker, EnvVar, ExperimentSpec, ImageSource
 from beaker.exceptions import ImageNotFound
 
 from rslp.log_utils import get_logger
 from rslp.utils.beaker import (
     DEFAULT_BUDGET,
     DEFAULT_WORKSPACE,
+    WekaMount,
     create_gcp_credentials_mount,
     get_base_env_vars,
     upload_image,
@@ -33,23 +33,6 @@ def get_command(project: str, workflow: str, extra_args: list[str]) -> list[str]
         extra_args: list of arguments to pass to the workflow.
     """
     return ["python", "-m", "rslp.main", project, workflow] + extra_args
-
-
-@dataclass
-class WekaMount:
-    """Specification of a Weka mount within a Beaker job."""
-
-    bucket_name: str
-    mount_path: str
-    sub_path: str | None = None
-
-    def to_data_mount(self) -> DataMount:
-        """Convert this WekaMount to a Beaker DataMount object."""
-        return DataMount(
-            source=DataSource(weka=self.bucket_name),
-            mount_path=self.mount_path,
-            sub_path=self.sub_path,
-        )
 
 
 def launch_job(

--- a/rslp/common/worker.py
+++ b/rslp/common/worker.py
@@ -25,10 +25,9 @@ from beaker import (
 )
 from google.cloud import pubsub_v1
 
-from rslp.launch_beaker import DEFAULT_WORKSPACE
 from rslp.log_utils import get_logger
 from rslp.main import run_workflow
-from rslp.utils.beaker import DEFAULT_BUDGET, get_base_env_vars
+from rslp.utils.beaker import DEFAULT_BUDGET, DEFAULT_WORKSPACE, get_base_env_vars
 
 logger = get_logger(__name__)
 

--- a/rslp/helios/README.md
+++ b/rslp/helios/README.md
@@ -1,0 +1,20 @@
+This module contains code to wrap Helios model for training in rslearn/rslearn_projects
+along with launcher for Helios fine-tuning experiments.
+
+## Helios Fine-tuning
+
+Launch Helios fine-tuning experiments with a given checkpoint:
+
+    python -m rslp.main helios launch_finetune --helios_checkpoint_path /weka/dfive-default/helios/checkpoints/henryh/8latent_mim_random_patch_disc_new_exit_zero_lr_4e-05_base_shallow_decoder/step95000/ --patch_size 4 --encoder_embedding_size 768 --experiment_prefix apr07test --image_name favyen/rslphelios --tasks '["eurosat"]' --configs '["finetune"]'
+
+The Weka `dfive-default` bucket will be automatically mounted at
+`/weka/dfive-default/`. Leave `--tasks` out to run on all tasks (see `data/helios/` for
+the list of model configuration files that will be used as templates for the
+fine-tuning experiments). `--configs` is similarly optional.
+
+If you need to create a new image, first create a copy of `rslearn_projects` repository
+with subfolders `rslearn` (containing https://github.com/allenai/rslearn) and
+`helios` (containing https://github.com/allenai/helios). Then run:
+
+    docker build -t rslphelios -f helios.Dockerfile .
+    beaker image create --name rslphelios rslphelios

--- a/rslp/helios/__init__.py
+++ b/rslp/helios/__init__.py
@@ -1,1 +1,7 @@
 """Helios model architecture."""
+
+from .launch_finetune import launch_finetune
+
+workflows = {
+    "launch_finetune": launch_finetune,
+}

--- a/rslp/helios/launch_finetune.py
+++ b/rslp/helios/launch_finetune.py
@@ -74,6 +74,9 @@ def launch_finetune(
                 )
                 config_str = config_str.replace("{PATCH_SIZE}", str(patch_size))
                 config_str = config_str.replace(
+                    "{256/PATCH_SIZE}", str(256 // patch_size)
+                )
+                config_str = config_str.replace(
                     "{ENCODER_EMBEDDING_SIZE}", str(encoder_embedding_size)
                 )
 

--- a/rslp/helios/launch_finetune.py
+++ b/rslp/helios/launch_finetune.py
@@ -1,0 +1,94 @@
+"""Launch Helios fine-tuning experiments."""
+
+import json
+import os
+import subprocess  # nosec
+import tempfile
+from pathlib import Path
+
+from rslp.log_utils import get_logger
+
+DEFAULT_RSLP_PROJECT = "helios_finetuning"
+CONFIG_BASE_DIR = Path("data/helios")
+DEFAULT_CLUSTER = [
+    "ai2/jupiter-cirrascale-2",
+    "ai2/saturn-cirrascale",
+    "ai2/neptune-cirrascale",
+]
+
+logger = get_logger(__name__)
+
+
+def launch_finetune(
+    helios_checkpoint_path: str,
+    experiment_prefix: str,
+    image_name: str,
+    tasks: list[str] | None = None,
+    rslp_project: str = DEFAULT_RSLP_PROJECT,
+    cluster: list[str] = DEFAULT_CLUSTER,
+) -> None:
+    """Launch Helios fine-tuning experiments.
+
+    Args:
+        helios_checkpoint_path: path to Helios checkpoint to fine-tune from.
+        experiment_prefix: prefix for the run name on W&B.
+        image_name: what Beaker image to use.
+        tasks: optional list of tasks to launch, e.g. ["eurosat",
+            "satlas_marine_infra"]. Default is to launch all tasks.
+        rslp_project: optional override for W&B project to use.
+        cluster: see beaker_train.
+    """
+    if tasks is None:
+        task_dirs = list(CONFIG_BASE_DIR.iterdir())
+    else:
+        task_dirs = [CONFIG_BASE_DIR / task_name for task_name in tasks]
+
+    with tempfile.TemporaryDirectory(dir=".") as tmp_dir:
+        # Need to use relative path from rslearn_projects folder since the config file
+        # will be copied into the Beaker experiment's rslearn_projects copy.
+        tmp_dir = os.path.relpath(tmp_dir)
+
+        for task_dir in task_dirs:
+            for config_fname in task_dir.iterdir():
+                experiment_id = (
+                    f"{experiment_prefix}_{task_dir.name}_{config_fname.name}"
+                )
+
+                # I can't figure out how to override Helios checkpoint_path from
+                # command-line since it appears in a list, so instead we create a copy
+                # of the configuration file in a temporary directory.
+                with config_fname.open() as f:
+                    config_str = f.read()
+                config_str = config_str.replace(
+                    "{CHECKPOINT_PATH}", helios_checkpoint_path
+                )
+
+                tmp_config_fname = os.path.join(tmp_dir, f"{experiment_id}.yaml")
+                with open(tmp_config_fname, "w") as f:
+                    f.write(config_str)
+
+                weka_mounts = [
+                    dict(bucket_name="dfive-default", mount_path="/weka/dfive-default")
+                ]
+
+                args = [
+                    "python",
+                    "-m",
+                    "rslp.main",
+                    "common",
+                    "beaker_train",
+                    "--config_path",
+                    tmp_config_fname,
+                    "--image_name",
+                    image_name,
+                    "--cluster",
+                    json.dumps(cluster),
+                    "--weka_mounts",
+                    json.dumps(weka_mounts),
+                    "--project_id",
+                    rslp_project,
+                    "--experiment_id",
+                    experiment_id,
+                ]
+                logger.info(f"Launching job by running: {args}")
+                subprocess.check_call(args)  # nosec

--- a/rslp/helios/model.py
+++ b/rslp/helios/model.py
@@ -31,6 +31,7 @@ class Helios(torch.nn.Module):
         checkpoint_path: str,
         selector: list[str | int] = [],
         forward_kwargs: dict[str, Any] = {},
+        random_initialization: bool = False,
     ):
         """Create a new Helios model.
 
@@ -41,6 +42,9 @@ class Helios(torch.nn.Module):
                 the sub-module that should be applied on the input images.
             forward_kwargs: additional arguments to pass to forward pass besides the
                 MaskedHeliosSample.
+            random_initialization: whether to skip loading the checkpoint so the
+                weights are randomly initialized. In this case, the checkpoint is only
+                used to define the model architecture.
         """
         super().__init__()
         self.forward_kwargs = forward_kwargs
@@ -55,8 +59,9 @@ class Helios(torch.nn.Module):
         model = model_config.build()
 
         # Load the checkpoint.
-        train_module_dir = f"{checkpoint_path}/model_and_optim"
-        load_model_and_optim_state(train_module_dir, model)
+        if not random_initialization:
+            train_module_dir = f"{checkpoint_path}/model_and_optim"
+            load_model_and_optim_state(train_module_dir, model)
 
         # Select just the portion of the model that we actually want to use.
         for part in selector:

--- a/rslp/launcher_lib.py
+++ b/rslp/launcher_lib.py
@@ -19,6 +19,7 @@ CODE_EXCLUDES = [
     ".env",
     ".mypy_cache",
     "lightning_logs",
+    "test_data",
     "wandb",
 ]
 

--- a/rslp/main.py
+++ b/rslp/main.py
@@ -51,7 +51,7 @@ def run_workflow(project: str, workflow: str, args: list[str]) -> None:
     workflow_fn = module.workflows[workflow]
     logger.info(f"running {workflow} for {project}")
     logger.info(f"args: {args}")
-    jsonargparse.CLI(workflow_fn, args=args)
+    jsonargparse.CLI(workflow_fn, args=args, as_positional=False)
 
 
 def main() -> None:

--- a/rslp/satlas/postprocess.py
+++ b/rslp/satlas/postprocess.py
@@ -85,17 +85,6 @@ def merge_points(
     for fname, cur_fc in tqdm.tqdm(outputs, total=len(fnames)):
         logger.debug("merging points from %s", fname)
 
-        # The projection information may be missing if there are no valid patches.
-        # In that case we can skip the file since it has neither valid patches that we
-        # need to track nor any predicted points.
-        if "crs" not in cur_fc["properties"]:
-            # Just do some sanity checks, there should be no features and no valid
-            # patches.
-            assert len(cur_fc["features"]) == 0
-            patch_list = list(cur_fc["properties"]["valid_patches"].values())
-            assert len(patch_list) == 1 and len(patch_list[0]) == 0
-            continue
-
         src_projection = Projection.deserialize(cur_fc["properties"])
         crs_str = str(src_projection.crs)
 

--- a/rslp/satlas/write_jobs.py
+++ b/rslp/satlas/write_jobs.py
@@ -178,12 +178,16 @@ def get_jobs(
     logger.info("Got %d total tasks", len(tasks))
 
     # Remove tasks where outputs are already computed.
-    existing_output_fnames = {out_fname.name for out_fname in UPath(out_path).iterdir()}
-    tasks = [
-        task
-        for task in tasks
-        if task.get_output_fname().name not in existing_output_fnames
-    ]
+    out_upath = UPath(out_path)
+    if out_upath.exists():
+        existing_output_fnames = {
+            out_fname.name for out_fname in UPath(out_path).iterdir()
+        }
+        tasks = [
+            task
+            for task in tasks
+            if task.get_output_fname().name not in existing_output_fnames
+        ]
     logger.info("Got %d tasks that are uncompleted", len(tasks))
 
     # Sample tasks down to user-provided count (max # tasks to run), if provided.

--- a/rslp/satlas/write_jobs.py
+++ b/rslp/satlas/write_jobs.py
@@ -214,9 +214,13 @@ def get_jobs(
             )
 
         cur_args = [
+            "--application",
             application.value.upper(),
+            "--out_path",
             out_path,
+            "--scratch_path",
             "/tmp/scratch/",
+            "--tasks",
             json.dumps([predict_task.serialize() for predict_task in predict_tasks]),
         ]
         jobs.append(cur_args)

--- a/rslp/sentinel2_vessel_attribute/README.md
+++ b/rslp/sentinel2_vessel_attribute/README.md
@@ -9,8 +9,8 @@ To populate the dataset:
 ```
 mkdir /path/to/dataset/
 cp data/sentinel2_vessel_attribute/config.json /path/to/dataset/config.json
-python -m rslp.main sentinel2_vessel_attribute create_windows detections_bigtable gs://rslearn-eai/datasets/sentinel2_vessel_attribute/artifacts/sentinel2_correlated_detections_bigtable/ gs://rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/ --workers 64
-python -m rslp.main sentinel2_vessel_attribute create_windows detections_jan_470k gs://rslearn-eai/datasets/sentinel2_vessel_attribute/artifacts/sentinel2_correlated_detections_jan_470k/ gs://rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/ --workers 64
+python -m rslp.main sentinel2_vessel_attribute create_windows --group detections_bigtable --csv_dir gs://rslearn-eai/datasets/sentinel2_vessel_attribute/artifacts/sentinel2_correlated_detections_bigtable/ --ds_path gs://rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/ --workers 64
+python -m rslp.main sentinel2_vessel_attribute create_windows --group detections_jan_470k --csv_dir gs://rslearn-eai/datasets/sentinel2_vessel_attribute/artifacts/sentinel2_correlated_detections_jan_470k/ --ds_path gs://rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/ --workers 64
 ```
 
 This puts the first batch of CSVs in one group ("detections_bigtable") and the second

--- a/rslp/sentinel2_vessels/job_launcher.py
+++ b/rslp/sentinel2_vessels/job_launcher.py
@@ -59,7 +59,9 @@ def launch_job(image_name: str, tasks: list[PredictionTask]) -> None:
             arguments=[
                 "sentinel2_vessels",
                 "predict",
+                "--tasks",
                 json.dumps(encoded_tasks),
+                "--scratch_path",
                 "/tmp/x/",
             ],
             constraints=Constraints(

--- a/rslp/utils/beaker.py
+++ b/rslp/utils/beaker.py
@@ -1,12 +1,30 @@
 """Utilities relating to Beaker jobs."""
 
 import os
+from dataclasses import dataclass
 
 from beaker import DataMount, DataSource, EnvVar, ImageSource
 from beaker.client import Beaker
 
 DEFAULT_WORKSPACE = "ai2/earth-systems"
 DEFAULT_BUDGET = "ai2/d5"
+
+
+@dataclass
+class WekaMount:
+    """Specification of a Weka mount within a Beaker job."""
+
+    bucket_name: str
+    mount_path: str
+    sub_path: str | None = None
+
+    def to_data_mount(self) -> DataMount:
+        """Convert this WekaMount to a Beaker DataMount object."""
+        return DataMount(
+            source=DataSource(weka=self.bucket_name),
+            mount_path=self.mount_path,
+            sub_path=self.sub_path,
+        )
 
 
 def get_base_env_vars(use_weka_prefix: bool = False) -> list[EnvVar]:

--- a/tests/integration/common/test_worker.py
+++ b/tests/integration/common/test_worker.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 
 from rslp.common.worker import worker_pipeline, write_jobs
 
+IDLE_TIMEOUT = 2
+
 
 class TestWorker:
     """Test the rslp.common.worker module."""
@@ -17,25 +19,24 @@ class TestWorker:
         worker_pipeline(
             project_id=os.environ["TEST_PUBSUB_PROJECT"],
             subscription_id=os.environ["TEST_PUBSUB_SUBSCRIPTION"],
-            idle_timeout=1,
+            idle_timeout=IDLE_TIMEOUT,
             flush_messages=True,
         )
         print("done flushing messages")
 
     def test_idle_timeout(self) -> None:
         """Verify that worker exits within about the idle timeout."""
-        idle_timeout = 2
         start_time = time.time()
         worker_pipeline(
             project_id=os.environ["TEST_PUBSUB_PROJECT"],
             subscription_id=os.environ["TEST_PUBSUB_SUBSCRIPTION"],
-            idle_timeout=idle_timeout,
+            idle_timeout=IDLE_TIMEOUT,
         )
         end_time = time.time()
         elapsed = end_time - start_time
         # Use 3 here in case worker decides to sleep twice (and then some extra time
         # elapses).
-        assert elapsed >= idle_timeout and elapsed <= 3 * idle_timeout
+        assert elapsed >= IDLE_TIMEOUT and elapsed <= 3 * IDLE_TIMEOUT
 
     def test_single_task(self, tmp_path: pathlib.Path) -> None:
         """Check that worker can do one task."""
@@ -59,7 +60,7 @@ class TestWorker:
         worker_pipeline(
             project_id=os.environ["TEST_PUBSUB_PROJECT"],
             subscription_id=os.environ["TEST_PUBSUB_SUBSCRIPTION"],
-            idle_timeout=1,
+            idle_timeout=IDLE_TIMEOUT,
         )
         # Verify that the file was created.
         assert dst_fname.exists()

--- a/tests/integration/common/test_worker.py
+++ b/tests/integration/common/test_worker.py
@@ -43,8 +43,9 @@ class TestWorker:
         dst_fname = tmp_path / "test_file"
         # Write the task to the test topic.
         job_args = [
+            "--fname",
             str(dst_fname),
-            # The contents to write.
+            "--contents",
             "abc",
         ]
         write_jobs(


### PR DESCRIPTION
Add code for launching Helios fine-tuning evaluations.

There is documentation in `rslp/helios/README.md` but basically you can launch evaluation like this:

```
python -m rslp.main helios launch_finetune --helios_checkpoint_path /weka/dfive-default/helios/checkpoints/henryh/8latent_mim_random_patch_disc_new_exit_zero_lr_4e-05_base_shallow_decoder/step95000/ --experiment_prefix apr07test --image_name favyen/rslphelios --tasks '["eurosat"]'
```

Other changes:
- The positional arguments were getting out of hand so I changed it so arguments passed via command-line are all passed with --flag instead of positional. Most of the documentation changes are related to this.
- Moved rslp.launch_beaker to rslp.common.beaker_train so that it can use the workflow interface which means it doesn't need extra argparse code.
- There are also some fixes for Satlas pipeline to work with some changes in rslearn.

Todos:
- Try DETR object detection head since it may be better for transformer backbones.
- See if there are more classification tasks that would be good to evaluate on.