### PR TITLE
fix docs for landsat model versions

### DIFF
--- a/ai2_docs/landsat_vessels/api_use.md
+++ b/ai2_docs/landsat_vessels/api_use.md
@@ -5,8 +5,8 @@ The Landsat Vessel Detection API provides a way to apply the Landsat scenes for 
 
 ## Overview
 - **Model Name**: Landsat Vessel Detection
-- **Model Version**: `v0.0.4`
-- **Tag**: `landsat_vessels_v0.0.4`
+- **Model Version**: `v0.0.6`
+- **Tag**: `landsat_vessels_v0.0.6`
 - **Last Updated**: `2025-02-14`
 
 
@@ -51,7 +51,7 @@ Prebuilt Docker images are available on GHCR. Use the following steps to pull an
 1. Pull the image from GHCR.
 
     ```bash
-    docker pull ghcr.io/allenai/landsat-vessel-detection:landsat_vessels_v0.0.4
+    docker pull ghcr.io/allenai/landsat-vessel-detection:landsat_vessels_v0.0.6
     ```
 
 2. Run the container. Note that you need to replace the `<port_number>` and `<path_to_service_account_key>` with the actual `LANDSAT_PORT` (if you use the default port, set it to `5555`) and path to your local service account key file, and keep the other arguments unchanged.
@@ -64,7 +64,7 @@ Prebuilt Docker images are available on GHCR. Use the following steps to pull an
     --env-file .env \
     --shm-size=15g \
     --gpus all \
-    ghcr.io/allenai/landsat-vessel-detection:landsat_vessels_v0.0.4
+    ghcr.io/allenai/landsat-vessel-detection:landsat_vessels_v0.0.6
     ```
 
 ## Making Requests to the API

--- a/ai2_docs/landsat_vessels/model_summary.md
+++ b/ai2_docs/landsat_vessels/model_summary.md
@@ -59,4 +59,6 @@ Below is an example of the missed vessels, a lot of them are only visible in the
 - **`v0.0.1`**: Initial model release. Offline evaluation metrics reported.
 - **`v0.0.2`**: Improved pansharpening, added error message to LandsatResponse.
 - **`v0.0.3`**: Increase crop size.
-- **`v0.0.4`**: Fix bug with RGB crops.
+- **`v0.0.4`**: Add Prometheus timers.
+- **`v0.0.5`**: Fix for new version of rslearn.
+- **`v0.0.6`**: Fix bug with RGB crops.


### PR DESCRIPTION
There were a couple missing versions in between that did not get documented.