### PR TITLE
Add CROMA/Helios fine-tuning configs for team meeting presentation.

### DIFF
--- a/one_off_projects/2025_04_29_helios_comparison/README.md
+++ b/one_off_projects/2025_04_29_helios_comparison/README.md
@@ -1,0 +1,2 @@
+This contains the configs used for fine-tuning evaluations for forest loss driver and
+ecosystem type mapping for the 2025-05-02 Ai2 Team Meeting presentation on Helios.

--- a/one_off_projects/2025_04_29_helios_comparison/croma.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/croma.yaml
@@ -1,0 +1,143 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.croma.Croma
+            init_args:
+              size: BASE
+              modality: SENTINEL2
+              image_resolution: 256
+        decoders:
+          detect:
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 768
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.LayerNorm
+                  init_args:
+                    normalized_shape: [192, 32, 32]
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 192
+                out_channels: 192
+                kernel_size: 3
+                activation:
+                  class_path: torch.nn.Identity
+            - class_path: rslearn.models.faster_rcnn.FasterRCNN
+              init_args:
+                downsample_factors: [8]
+                num_channels: 192
+                num_classes: 3
+                anchor_sizes: [[32]]
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/marine_infra/dataset_v1/20241210/
+    inputs:
+      image:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          detect:
+            class_path: rslp.satlas.train.MarineInfraTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "platform", "turbine"]
+              box_size: 15
+              remap_values: [[0, 0.25], [0, 255]]
+              image_bands: [2, 1, 0]
+              exclude_by_center: true
+              enable_map_metric: true
+              enable_f1_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95], [0.1], [0.2], [0.3], [0.4], [0.5], [0.6], [0.7], [0.8], [0.9]]
+              skip_unknown_categories: true
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          detect:
+            targets: "targets"
+    batch_size: 4
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              image: []
+            output_selector: sentinel2
+        - class_path: rslearn.models.croma.CromaNormalize
+    train_config:
+      patch_size: 256
+      tags:
+        split: train
+        nonempty: "yes"
+    val_config:
+      patch_size: 256
+      tags:
+        split: val
+        nonempty: "yes"
+    test_config:
+      patch_size: 256
+      tags:
+        split: val
+        nonempty: "yes"
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        path: placeholder
+        output_layer: output
+        selector: ["detect"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_detect/mAP
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250429_satlas_marine_infra_croma_09

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/croma_base_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/croma_base_finetune.yaml
@@ -1,0 +1,152 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.croma.Croma
+                init_args:
+                  size: BASE
+                  modality: SENTINEL2
+                  image_resolution: 128
+              image_channels: 12
+              image_key: "sentinel2"
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[8, 768]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+                num_channels: {4: 512, 2: 256, 1: 128}
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 2
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2
+        - class_path: rslearn.models.croma.CromaNormalize
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2
+        - class_path: rslearn.models.croma.CromaNormalize
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["sentinel2", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_croma_base_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/croma_base_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/croma_base_frozen.yaml
@@ -1,0 +1,151 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.croma.Croma
+                init_args:
+                  size: BASE
+                  modality: SENTINEL2
+                  image_resolution: 128
+              image_channels: 12
+              image_key: "sentinel2"
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[8, 768]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+                num_channels: {4: 512, 2: 256, 1: 128}
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 2
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2
+        - class_path: rslearn.models.croma.CromaNormalize
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2
+        - class_path: rslearn.models.croma.CromaNormalize
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["sentinel2", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_croma_base_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_galileo_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_galileo_finetune.yaml
@@ -1,0 +1,155 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "/weka/dfive-default/helios/checkpoints/henryh/3_galileo_contrastive_base_decoder_4_lr_0.0001_weight_0.05/step312250"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 8
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[8, 768]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+                num_channels: {4: 512, 2: 256, 1: 128}
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 2
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["sentinel2_l2a", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_helios_galileo_finetune_ps8_01

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_galileo_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_galileo_frozen.yaml
@@ -1,0 +1,154 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "/weka/dfive-default/helios/checkpoints/henryh/3_galileo_contrastive_base_decoder_4_lr_0.0001_weight_0.05/step312250"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 4
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 768]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+                num_channels: {2: 256, 1: 128}
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 2
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["sentinel2_l2a", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_helios_galileo_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_st_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_st_finetune.yaml
@@ -1,0 +1,155 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "/weka/dfive-default/helios/checkpoints/favyen/20250424_budget6000hwp20/step233500"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 4
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 768]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+                num_channels: {2: 256, 1: 128}
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 2
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["sentinel2_l2a", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_helios_st_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_st_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/helios_st_frozen.yaml
@@ -1,0 +1,154 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslp.helios.model.Helios
+            init_args:
+              checkpoint_path: "/weka/dfive-default/helios/checkpoints/favyen/20250424_budget6000hwp20/step233500"
+              selector: ["encoder"]
+              forward_kwargs:
+                patch_size: 4
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 768]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+                num_channels: {2: 256, 1: 128}
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 2
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["sentinel2_l2a", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_helios_st_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_ms_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_ms_finetune.yaml
@@ -1,0 +1,200 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_imagenet_ms_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_ms_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_ms_frozen.yaml
@@ -1,0 +1,199 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_imagenet_ms_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_rgb_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_rgb_finetune.yaml
@@ -1,0 +1,174 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_imagenet_rgb_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_rgb_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/imagenet_rgb_frozen.yaml
@@ -1,0 +1,173 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_imagenet_rgb_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_ms_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_ms_finetune.yaml
@@ -1,0 +1,204 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-band-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_satlaspretrain_ms_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_ms_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_ms_frozen.yaml
@@ -1,0 +1,203 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-band-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_satlaspretrain_ms_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_rgb_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_rgb_finetune.yaml
@@ -1,0 +1,178 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_satlaspretrain_rgb_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_rgb_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/ecosystem/satlaspretrain_rgb_frozen.yaml
@@ -1,0 +1,177 @@
+model:
+  class_path: rslp.maldives_ecosystem_mapping.train.CMLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2, 3, 4, 5]]
+        decoders:
+          segment:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 128], [8, 256], [16, 512], [32, 1024]]
+                out_channels: 17
+                conv_layers_per_resolution: 2
+            - class_path: rslearn.train.tasks.segmentation.SegmentationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/maldives_ecosystem_mapping/dataset_v1/20241017/
+    inputs:
+      sentinel2_0:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_1:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.1"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_2:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.2"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_3:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.3"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_4:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.4"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      sentinel2_5:
+        data_type: "raster"
+        layers: ["sentinel2_with_planet.5"]
+        bands: ["B04", "B03", "B02"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          segment:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 17
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          segment:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 32
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+    train_config:
+      patch_size: 128
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - sentinel2_0
+              - sentinel2_1
+              - sentinel2_2
+              - sentinel2_3
+              - sentinel2_4
+              - sentinel2_5
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2_0: []
+              sentinel2_1: []
+              sentinel2_2: []
+              sentinel2_3: []
+              sentinel2_4: []
+              sentinel2_5: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors: ["image", "target/segment/classes", "target/segment/valid"]
+      groups: ["crops_planetscope"]
+      tags:
+        split: train
+    val_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+    test_config:
+      patch_size: 128
+      groups: ["crops_planetscope"]
+      tags:
+        split: val
+trainer:
+  max_epochs: 500
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        every_n_epochs: 50
+        save_last: true
+        monitor: val_segment/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_ecosystem_satlaspretrain_rgb_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/croma_base_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/croma_base_finetune.yaml
@@ -1,0 +1,143 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        # We use SimpleTimeSeries not for time series but just to concatenate the
+        # feature maps for pre-forest-loss and post-forest-loss.
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.croma.Croma
+                init_args:
+                  size: BASE
+                  modality: SENTINEL2
+                  image_resolution: 64
+              image_channels: 12
+              image_key: "sentinel2"
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 1536
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 8
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: sentinel2
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+            image_selectors:
+              - sentinel2
+        - class_path: rslearn.models.croma.CromaNormalize
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors:
+              - sentinel2
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_croma_base_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/croma_base_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/croma_base_frozen.yaml
@@ -1,0 +1,142 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        # We use SimpleTimeSeries not for time series but just to concatenate the
+        # feature maps for pre-forest-loss and post-forest-loss.
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.croma.Croma
+                init_args:
+                  size: BASE
+                  modality: SENTINEL2
+                  image_resolution: 64
+              image_channels: 12
+              image_key: "sentinel2"
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 1536
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 8
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: sentinel2
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+            image_selectors:
+              - sentinel2
+        - class_path: rslearn.models.croma.CromaNormalize
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors:
+              - sentinel2
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_croma_base_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_galileo_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_galileo_finetune.yaml
@@ -1,0 +1,150 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        # We use SimpleTimeSeries not for time series but just to concatenate the
+        # feature maps for pre-forest-loss and post-forest-loss.
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslp.helios.model.Helios
+                init_args:
+                  checkpoint_path: "/weka/dfive-default/helios/checkpoints/henryh/3_galileo_contrastive_base_decoder_4_lr_0.0001_weight_0.05/step312250"
+                  selector: ["encoder"]
+                  forward_kwargs:
+                    patch_size: 4
+                  patch_size: 4
+                  embedding_size: 768
+              image_channels: 36
+              image_key: "sentinel2_l2a"
+              groups: [[0], [1]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 1536
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 8
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: sentinel2_l2a
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+            image_selectors:
+              - sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors:
+              - sentinel2_l2a
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_helios_galileo_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_galileo_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_galileo_frozen.yaml
@@ -1,0 +1,149 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        # We use SimpleTimeSeries not for time series but just to concatenate the
+        # feature maps for pre-forest-loss and post-forest-loss.
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslp.helios.model.Helios
+                init_args:
+                  checkpoint_path: "/weka/dfive-default/helios/checkpoints/henryh/3_galileo_contrastive_base_decoder_4_lr_0.0001_weight_0.05/step312250"
+                  selector: ["encoder"]
+                  forward_kwargs:
+                    patch_size: 4
+                  patch_size: 4
+                  embedding_size: 768
+              image_channels: 36
+              image_key: "sentinel2_l2a"
+              groups: [[0], [1]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 1536
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 8
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: sentinel2_l2a
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+            image_selectors:
+              - sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors:
+              - sentinel2_l2a
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_helios_galileo_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_st_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_st_finetune.yaml
@@ -1,0 +1,150 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        # We use SimpleTimeSeries not for time series but just to concatenate the
+        # feature maps for pre-forest-loss and post-forest-loss.
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslp.helios.model.Helios
+                init_args:
+                  checkpoint_path: "/weka/dfive-default/helios/checkpoints/favyen/20250424_budget6000hwp20/step233500"
+                  selector: ["encoder"]
+                  forward_kwargs:
+                    patch_size: 4
+                  patch_size: 4
+                  embedding_size: 768
+              image_channels: 36
+              image_key: "sentinel2_l2a"
+              groups: [[0], [1]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 1536
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 8
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: sentinel2_l2a
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+            image_selectors:
+              - sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors:
+              - sentinel2_l2a
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_helios_st_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_st_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/helios_st_frozen.yaml
@@ -1,0 +1,149 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        # We use SimpleTimeSeries not for time series but just to concatenate the
+        # feature maps for pre-forest-loss and post-forest-loss.
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslp.helios.model.Helios
+                init_args:
+                  checkpoint_path: "/weka/dfive-default/helios/checkpoints/favyen/20250424_budget6000hwp20/step233500"
+                  selector: ["encoder"]
+                  forward_kwargs:
+                    patch_size: 4
+                  patch_size: 4
+                  embedding_size: 768
+              image_channels: 36
+              image_key: "sentinel2_l2a"
+              groups: [[0], [1]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 1536
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 8
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: sentinel2_l2a
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+            image_selectors:
+              - sentinel2_l2a
+        - class_path: rslp.helios.norm.HeliosNormalize
+          init_args:
+            config_fname: "/opt/helios/data/norm_configs/computed.json"
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        - class_path: rslearn.train.transforms.flip.Flip
+          init_args:
+            image_selectors:
+              - sentinel2_l2a
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_helios_st_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_ms_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_ms_finetune.yaml
@@ -1,0 +1,160 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_imagenet_ms_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_ms_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_ms_frozen.yaml
@@ -1,0 +1,159 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_imagenet_ms_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_rgb_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_rgb_finetune.yaml
@@ -1,0 +1,138 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250424/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 255
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_imagenet_rgb_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_rgb_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/imagenet_rgb_frozen.yaml
@@ -1,0 +1,137 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250424/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 255
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_imagenet_rgb_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_finetune.yaml
@@ -1,0 +1,142 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250424/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 255
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_satlaspretrain_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_frozen.yaml
@@ -1,0 +1,141 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 3
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 3
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250424/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["R", "G", "B"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 255
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_satlaspretrain_frozen_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_ms_finetune.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_ms_finetune.yaml
@@ -1,0 +1,164 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-band-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 5
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_satlaspretrain_ms_finetune_00

--- a/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_ms_frozen.yaml
+++ b/one_off_projects/2025_04_29_helios_comparison/forest_loss_driver/satlaspretrain_ms_frozen.yaml
@@ -1,0 +1,163 @@
+model:
+  class_path: rslp.forest_loss_driver.train.ForestLossLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.simple_time_series.SimpleTimeSeries
+            init_args:
+              encoder:
+                class_path: rslearn.models.swin.Swin
+                init_args:
+                  pretrained: true
+                  input_channels: 9
+                  output_layers: [1, 3, 5, 7]
+              image_channels: 9
+              groups: [[0, 1, 2], [3, 4, 5]]
+        decoders:
+          class:
+            - class_path: rslearn.models.pooling_decoder.PoolingDecoder
+              init_args:
+                in_channels: 2048
+                out_channels: 10
+                num_conv_layers: 1
+                num_fc_layers: 2
+            - class_path: rslearn.train.tasks.classification.ClassificationHead
+    lr: 0.0001
+    plateau: true
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 10
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-band-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "encoder.0.encoder.model."]
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: gs://rslearn-eai/datasets/forest_loss_driver/dataset_v1/20250429/
+    inputs:
+      pre_0:
+        data_type: "raster"
+        layers: ["best_pre_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_1:
+        data_type: "raster"
+        layers: ["best_pre_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      pre_2:
+        data_type: "raster"
+        layers: ["best_pre_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_0:
+        data_type: "raster"
+        layers: ["best_post_0"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_1:
+        data_type: "raster"
+        layers: ["best_post_1"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      post_2:
+        data_type: "raster"
+        layers: ["best_post_2"]
+        bands: ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+        passthrough: true
+      label:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          class:
+            class_path: rslp.forest_loss_driver.train.ForestLossTask
+            init_args:
+              property_name: "new_label"
+              classes: ["agriculture", "mining", "airstrip", "road", "logging", "burned", "landslide", "hurricane", "river", "none"]
+              allow_invalid: true
+              metric_kwargs:
+                average: "micro"
+              prob_property: "probs"
+        input_mapping:
+          class:
+            label: "targets"
+    batch_size: 32
+    num_workers: 64
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 3000
+            valid_range: [0, 1]
+            bands: [0, 1, 2]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.normalize.Normalize
+          init_args:
+            mean: 0
+            std: 8160
+            valid_range: [0, 1]
+            bands: [3, 4, 5, 6, 7, 8]
+            selectors:
+              - pre_0
+              - pre_1
+              - pre_2
+              - post_0
+              - post_1
+              - post_2
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              pre_0: []
+              pre_1: []
+              pre_2: []
+              post_0: []
+              post_1: []
+              post_2: []
+            output_selector: image
+        - class_path: rslearn.train.transforms.pad.Pad
+          init_args:
+            mode: "center"
+            size: 64
+        - class_path: rslearn.train.transforms.flip.Flip
+      groups: ["peru_interesting", "peru3", "peru3_flagged_in_peru", "nadia2", "nadia3", "brazil_interesting"]
+    train_config:
+      tags:
+        split: train
+    val_config:
+      tags:
+        split: val
+    test_config:
+      tags:
+        split: val
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0, "encoder", "model"]
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_class/accuracy
+        mode: max
+rslp_project: 2025_04_29_helios_comparison
+rslp_experiment: 20250501_forest_loss_driver_satlaspretrain_ms_frozen_00

--- a/rslp/helios/model.py
+++ b/rslp/helios/model.py
@@ -32,6 +32,8 @@ class Helios(torch.nn.Module):
         selector: list[str | int] = [],
         forward_kwargs: dict[str, Any] = {},
         random_initialization: bool = False,
+        embedding_size: int | None = None,
+        patch_size: int | None = None,
     ):
         """Create a new Helios model.
 
@@ -45,9 +47,14 @@ class Helios(torch.nn.Module):
             random_initialization: whether to skip loading the checkpoint so the
                 weights are randomly initialized. In this case, the checkpoint is only
                 used to define the model architecture.
+            embedding_size: optional embedding size to report via
+                get_backbone_channels.
+            patch_size: optional patch size to report via get_backbone_channels.
         """
         super().__init__()
         self.forward_kwargs = forward_kwargs
+        self.embedding_size = embedding_size
+        self.patch_size = patch_size
 
         # Load the model config and initialize it.
         # We avoid loading the train module here because it depends on running within
@@ -136,3 +143,17 @@ class Helios(torch.nn.Module):
         # Pool over the modalities, so we get one BCHW feature map.
         pooled = torch.stack(features, dim=0).mean(dim=0)
         return [pooled]
+
+    def get_backbone_channels(self) -> list:
+        """Returns the output channels of this model when used as a backbone.
+
+        The output channels is a list of (downsample_factor, depth) that corresponds
+        to the feature maps that the backbone returns. For example, an element [2, 32]
+        indicates that the corresponding feature map is 1/2 the input resolution and
+        has 32 channels.
+
+        Returns:
+            the output channels of the backbone as a list of (downsample_factor, depth)
+            tuples.
+        """
+        return [(self.patch_size, self.embedding_size)]


### PR DESCRIPTION
Add CROMA/Helios fine-tuning configs for team meeting presentation

I also added embedding_size/patch_size arguments to Helios so that it can return the right values for get_backbone_channels. This is used by the SimpleTimeSeries module (which is needed for comparing the bitemporal images for forest loss driver classification).