### PR TITLE
Fix monthly image data sources in satlas module

### DIFF
--- a/rslp/satlas/data_sources.py
+++ b/rslp/satlas/data_sources.py
@@ -241,11 +241,12 @@ class MonthlyAzureSentinel2(DataSource):
         # This only makes sense for mosaic space mode.
         assert query_config.space_mode == SpaceMode.MOSAIC
 
+        client, _ = self.sentinel2._load_client()
         groups = []
         for geometry in geometries:
             # This part is the same as in base Sentinel2 class.
             wgs84_geometry = geometry.to_projection(WGS84_PROJECTION)
-            result = self.sentinel2.client.search(
+            result = client.search(
                 collections=[self.sentinel2.COLLECTION_NAME],
                 intersects=shapely.to_geojson(wgs84_geometry.shp),
                 datetime=wgs84_geometry.time_range,
@@ -353,11 +354,12 @@ class MonthlySentinel1(DataSource):
         # This only makes sense for mosaic space mode.
         assert query_config.space_mode == SpaceMode.MOSAIC
 
+        client, _ = self.sentinel1._load_client()
         groups = []
         for geometry in geometries:
             # This part is the same as in base Sentinel1 class.
             wgs84_geometry = geometry.to_projection(WGS84_PROJECTION)
-            result = self.sentinel1.client.search(
+            result = client.search(
                 collections=[self.sentinel1.COLLECTION_NAME],
                 intersects=shapely.to_geojson(wgs84_geometry.shp),
                 datetime=wgs84_geometry.time_range,


### PR DESCRIPTION
They were broken because of changes in rslearn where client is no longer created when PlanetaryComputer is initialized, instead it is lazily created.

We already have a test for this but it wasn't triggered because none of the code in the module changed here. I think we need a recurring weekly test run that runs all of the tests but we can do it in a later PR.