### PR TITLE
OlmoEarth fine-tuning evaluations

### DIFF
--- a/data/helios_v3/README.md
+++ b/data/helios_v3/README.md
@@ -1,0 +1,31 @@
+These model and task configs are designed to work with rslp.olmoearth_evals, which
+provides an adapter model to allow the inputs from all of the tasks to be consistent
+with all the baseline models we want to evaluate.
+
+Here is an example of launching a 2D grid of models and tasks:
+
+```
+python data/helios_v3/run.py --model croma olmoearth panopticon presto satlaspretrain terramind --task pastis_uni pastis_ts --prefix 20251006
+```
+
+Not all models support all modalities or multi-modality.
+
+- AnySat: supports all tasks.
+- Clay: supports Sentinel-1/Sentinel-2/Landsat, but only one modality at a time.
+- Copernicus-FM: supports Sentinel-1 and Sentinel-2.
+- CROMA: supports Sentinel-1 and Sentinel-2.
+- OlmoEarth: supports all tasks.
+- Panopticon: supports all tasks.
+- Presto: supports Sentinel-1 and Sentinel-2.
+- Prithvi: supports Sentinel-2 and Landsat, although it's not designed for non-HLS Sentinel-2.
+- SatlasPretrain: in this eval it only supports Sentinel-2.
+- TerraMind: supports Sentinel-1 and Sentinel-2.
+
+```
+# Sentinel-2 tasks.
+python data/helios_v3/run.py --model anysat clay copernicusfm croma olmoearth panopticon presto prithvi satlaspretrain terramind --task pastis_uni pastis_ts marine_infra_uni marine_infra_ts wind_turbine_uni wind_turbine_ts solar_farm_uni solar_farm_ts sentinel2_vessel_length sentinel2_vessel_type sentinel2_vessels --prefix 20251007b
+# Sentinel-1 + Sentinel-2 tasks.
+python data/helios_v3/run.py --model anysat copernicusfm croma olmoearth panopticon presto terramind --task pastis_mm marine_infra_mm wind_turbine_mm solar_farm_mm --prefix 20251007b
+# Sentinel-1 tasks.
+python data/helios_v3/run.py --model anysat clay copernicusfm croma olmoearth panopticon presto terramind --task sentinel1_vessels --prefix 20251007b
+```

--- a/data/helios_v3/models/anysat.yaml
+++ b/data/helios_v3/models/anysat.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/clay.yaml
+++ b/data/helios_v3/models/clay.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0, "encoder"]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/copernicusfm.yaml
+++ b/data/helios_v3/models/copernicusfm.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0, "encoder"]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/croma.yaml
+++ b/data/helios_v3/models/croma.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0, "encoder"]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/olmoearth.yaml
+++ b/data/helios_v3/models/olmoearth.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/panopticon.yaml
+++ b/data/helios_v3/models/panopticon.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0, "encoder"]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/presto.yaml
+++ b/data/helios_v3/models/presto.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/prithvi.yaml
+++ b/data/helios_v3/models/prithvi.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/satlaspretrain.yaml
+++ b/data/helios_v3/models/satlaspretrain.yaml
@@ -1,0 +1,12 @@
+model:
+  init_args:
+    restore_config:
+      restore_path: https://ai2-public-datasets.s3.amazonaws.com/satlas/satlas-model-v1-lowres-band-multi.pth
+      remap_prefixes:
+        - ["backbone.backbone.backbone.", "model.encoder.0.encoder.model."]
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0, "encoder", "model"]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/models/terramind.yaml
+++ b/data/helios_v3/models/terramind.yaml
@@ -1,0 +1,6 @@
+trainer:
+  callbacks+:
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "model", "encoder", 0, "encoder"]
+        unfreeze_at_epoch: 20

--- a/data/helios_v3/run.py
+++ b/data/helios_v3/run.py
@@ -1,0 +1,79 @@
+"""Launch OlmoEarth fine-tuning evals."""
+
+import argparse
+import subprocess  # nosec
+
+TASK_CONFIGS = {
+    "pastis_uni": ["pastis_base"],
+    "pastis_ts": ["pastis_base", "pastis_ts"],
+    "pastis_mm": ["pastis_base", "pastis_mm"],
+    "marine_infra_uni": ["marine_infra_base"],
+    "marine_infra_ts": ["marine_infra_base", "marine_infra_ts"],
+    "marine_infra_mm": ["marine_infra_base", "marine_infra_mm"],
+    "solar_farm_uni": ["solar_farm_base"],
+    "solar_farm_ts": ["solar_farm_base", "solar_farm_ts"],
+    "solar_farm_mm": ["solar_farm_base", "solar_farm_mm"],
+    "wind_turbine_uni": ["wind_turbine_base"],
+    "wind_turbine_ts": ["wind_turbine_base", "wind_turbine_ts"],
+    "wind_turbine_mm": ["wind_turbine_base", "wind_turbine_mm"],
+    "sentinel1_vessels": ["sentinel1_vessels"],
+    "sentinel2_vessel_length": ["sentinel2_vessel_length"],
+    "sentinel2_vessel_type": ["sentinel2_vessel_type"],
+    "sentinel2_vessels": ["sentinel2_vessels"],
+}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Launch OlmoEarth fine-tuning evaluations"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        nargs="*",
+        required=True,
+        help="Models to evaluate",
+    )
+    parser.add_argument(
+        "--task",
+        type=str,
+        nargs="*",
+        required=True,
+        help="Tasks to evaluate",
+    )
+    parser.add_argument(
+        "--prefix",
+        type=str,
+        required=True,
+        help="Experiment prefix",
+    )
+    args = parser.parse_args()
+
+    for model in args.model:
+        for task in args.task:
+            basic_args = [
+                "python",
+                "-m",
+                "rslp.main",
+                "common",
+                "beaker_train",
+                "--project_id",
+                "2025_10_03_downstream_finetuning",
+                "--experiment_id",
+                f"{args.prefix}_{task}_{model}",
+                "--cluster+=ai2/jupiter",
+                "--cluster+=ai2/ceres",
+                '--weka_mounts+={"bucket_name":"dfive-default","mount_path":"/weka/dfive-default"}',
+                "--image_name",
+                "favyen/rslphelios15",
+                "--priority",
+                "urgent",
+                "--extra_env_vars",
+                '{"EVAL_ADAPTER_MODEL_ID": "' + model + '"}',
+            ]
+            task_config_args = [
+                f"--config_paths+=data/helios_v3/tasks/{cfg_fname}.yaml"
+                for cfg_fname in TASK_CONFIGS[task]
+            ]
+            model_config_args = [f"--config_paths+=data/helios_v3/models/{model}.yaml"]
+            subprocess.check_call(basic_args + task_config_args + model_config_args)  # nosec

--- a/data/helios_v3/tasks/marine_infra_base.yaml
+++ b/data/helios_v3/tasks/marine_infra_base.yaml
@@ -1,0 +1,122 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel2"]
+        task_type: "detect"
+        task_name: "marine_infra"
+        task_channels: 3
+        task_timesteps: 1
+    lr: 0.0001
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 0
+        cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/marine_infra/dataset_v1/20250605/
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslp.satlas.train.MarineInfraTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "platform", "turbine"]
+              box_size: 15
+              remap_values: [[0, 0.25], [0, 255]]
+              image_bands: [2, 1, 0]
+              exclude_by_center: true
+              enable_map_metric: false
+              enable_f1_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95]]
+              skip_unknown_categories: true
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          eval_task:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2"]
+        # This is for Faster R-CNN head to know the image size.
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "detect"
+            task_name: "marine_infra"
+            task_channels: 3
+            task_timesteps: 1
+    train_config:
+      patch_size: 128
+      tags:
+        olmoearth_evals_split: train
+      # There are many validation patches due to the small patch size, so we set random
+      # sampler to increase the training epoch size to compensate.
+      sampler:
+        class_path: rslearn.train.dataset.RandomSamplerFactory
+        init_args:
+          replacement: true
+          num_samples: 65536
+    val_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: val
+    test_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: test
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/F1
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/marine_infra_mm.yaml
+++ b/data/helios_v3/tasks/marine_infra_mm.yaml
@@ -1,0 +1,56 @@
+model:
+  init_args:
+    model:
+      init_args:
+        input_modalities: ["sentinel2", "sentinel1"]
+        task_timesteps: 4
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      sentinel1:
+        data_type: "raster"
+        layers: ["sentinel1_ascending", "sentinel1_ascending.1", "sentinel1_ascending.2", "sentinel1_ascending.3"]
+        bands: ["vv", "vh"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.sentinel1.Sentinel1ToDecibels
+          init_args:
+            selectors: ["sentinel1"]
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2", "sentinel1"]
+        # This is for Faster R-CNN head to know the image size.
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2", "sentinel1"]
+            task_type: "detect"
+            task_name: "marine_infra"
+            task_channels: 3
+            task_timesteps: 4

--- a/data/helios_v3/tasks/marine_infra_ts.yaml
+++ b/data/helios_v3/tasks/marine_infra_ts.yaml
@@ -1,0 +1,45 @@
+model:
+  init_args:
+    model:
+      init_args:
+        task_timesteps: 4
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2"]
+        # This is for Faster R-CNN head to know the image size.
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "detect"
+            task_name: "marine_infra"
+            task_channels: 3
+            task_timesteps: 4

--- a/data/helios_v3/tasks/pastis_base.yaml
+++ b/data/helios_v3/tasks/pastis_base.yaml
@@ -1,0 +1,90 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel2"]
+        task_type: "segment"
+        task_name: "pastis"
+        task_channels: 20
+        task_timesteps: 1
+    lr: 0.0001
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 0
+        cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/pastis/rslearn_dataset/
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B11", "B12"]
+        passthrough: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["class"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 20
+              remap_values: [[0, 1], [0, 255]]
+              zero_is_invalid: true
+              metric_kwargs:
+                average: "micro"
+              enable_miou_metric: true
+        input_mapping:
+          eval_task:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              # PASTIS is missing B01 and B09.
+              # We use B02 to fill in B01 and B8A to fill in B09.
+              sentinel2: [0, 0, 1, 2, 3, 4, 5, 6, 7, 7, 8, 9]
+            output_selector: sentinel2
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "segment"
+            task_name: "pastis"
+            task_channels: 20
+            task_timesteps: 1
+    train_config:
+      groups: ["fold1", "fold2", "fold3"]
+    val_config:
+      groups: ["fold4"]
+    test_config:
+      groups: ["fold5"]
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/mean_iou
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/pastis_mm.yaml
+++ b/data/helios_v3/tasks/pastis_mm.yaml
@@ -1,0 +1,45 @@
+model:
+  init_args:
+    model:
+      init_args:
+        task_timesteps: 12
+        input_modalities: ["sentinel2", "sentinel1"]
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3", "sentinel2.4", "sentinel2.5", "sentinel2.6", "sentinel2.7", "sentinel2.8", "sentinel2.9", "sentinel2.10", "sentinel2.11"]
+        bands: ["B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B11", "B12"]
+        passthrough: true
+        load_all_layers: true
+      sentinel1:
+        data_type: "raster"
+        layers: ["s1d", "s1d.1", "s1d.2", "s1d.3", "s1d.4", "s1d.5", "s1d.6", "s1d.7", "s1d.8", "s1d.9", "s1d.10", "s1d.11"]
+        bands: ["vv", "vh"]
+        passthrough: true
+        load_all_layers: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["class"]
+        is_target: true
+    batch_size: 2
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.select_bands.SelectBands
+          init_args:
+            # PASTIS is missing B01 and B09.
+            # We use B02 to fill in B01 and B8A to fill in B09.
+            band_indices: [0, 0, 1, 2, 3, 4, 5, 6, 7, 7, 8, 9]
+            num_bands_per_timestep: 10
+            input_selector: sentinel2
+            output_selector: sentinel2
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2", "sentinel1"]
+            task_type: "segment"
+            task_name: "pastis"
+            task_channels: 20
+            task_timesteps: 12

--- a/data/helios_v3/tasks/pastis_ts.yaml
+++ b/data/helios_v3/tasks/pastis_ts.yaml
@@ -1,0 +1,38 @@
+model:
+  init_args:
+    model:
+      init_args:
+        task_timesteps: 12
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3", "sentinel2.4", "sentinel2.5", "sentinel2.6", "sentinel2.7", "sentinel2.8", "sentinel2.9", "sentinel2.10", "sentinel2.11"]
+        bands: ["B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B11", "B12"]
+        passthrough: true
+        load_all_layers: true
+      targets:
+        data_type: "raster"
+        layers: ["label"]
+        bands: ["class"]
+        is_target: true
+    batch_size: 2
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.select_bands.SelectBands
+          init_args:
+            # PASTIS is missing B01 and B09.
+            # We use B02 to fill in B01 and B8A to fill in B09.
+            band_indices: [0, 0, 1, 2, 3, 4, 5, 6, 7, 7, 8, 9]
+            num_bands_per_timestep: 10
+            input_selector: sentinel2
+            output_selector: sentinel2
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "segment"
+            task_name: "pastis"
+            task_channels: 20
+            task_timesteps: 12

--- a/data/helios_v3/tasks/sentinel1_vessels.yaml
+++ b/data/helios_v3/tasks/sentinel1_vessels.yaml
@@ -1,0 +1,123 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel1"]
+        task_type: "detect"
+        task_name: "sentinel1_vessels"
+        task_channels: 2
+        task_timesteps: 1
+    lr: 0.0001
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 0
+        cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/sentinel1_vessels/dataset_v1/20250602/
+    inputs:
+      sentinel1:
+        data_type: "raster"
+        layers: ["sentinel1"]
+        bands: ["vv", "vh"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: INT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslearn.train.tasks.detection.DetectionTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "vessel"]
+              box_size: 15
+              remap_values: [[0, 1], [0, 255]]
+              image_bands: [1, 1, 1]
+              exclude_by_center: true
+              score_threshold: 0.5
+              enable_map_metric: false
+              enable_f1_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95]]
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          eval_task:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.sentinel1.Sentinel1ToDecibels
+          init_args:
+            selectors: ["sentinel1"]
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel1"]
+        # This is for Faster R-CNN head to know the image size.
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel1: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel1"]
+            task_type: "detect"
+            task_name: "sentinel1_vessels"
+            task_channels: 2
+            task_timesteps: 1
+    train_config:
+      patch_size: 128
+      tags:
+        olmoearth_evals_split: train
+      sampler:
+        class_path: rslearn.train.dataset.RandomSamplerFactory
+        init_args:
+          replacement: true
+          num_samples: 32768
+    val_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: val
+    test_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: test
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/F1
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/sentinel2_vessel_length.yaml
+++ b/data/helios_v3/tasks/sentinel2_vessel_length.yaml
@@ -1,0 +1,81 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel2"]
+        task_type: "regress"
+        task_name: "sentinel2_vessel_length"
+        task_channels: 1
+        task_timesteps: 1
+    lr: 0.0001
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+        dtype: FLOAT32
+      info:
+        data_type: "vector"
+        layers: ["info"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslearn.train.tasks.regression.RegressionTask
+            init_args:
+              property_name: "length"
+              allow_invalid: true
+              scale_factor: 0.01
+              metric_mode: l1
+        input_mapping:
+          eval_task:
+            info: "targets"
+    batch_size: 32
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "regress"
+            task_name: "sentinel2_vessel_length"
+            task_channels: 1
+            task_timesteps: 1
+    train_config:
+      tags:
+        olmoearth_evals_split: "train"
+    val_config:
+      tags:
+        olmoearth_evals_split: "val"
+    test_config:
+      tags:
+        olmoearth_evals_split: "test"
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/l1
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/sentinel2_vessel_type.yaml
+++ b/data/helios_v3/tasks/sentinel2_vessel_type.yaml
@@ -1,0 +1,82 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel2"]
+        task_type: "classify"
+        task_name: "sentinel2_vessel_type"
+        task_channels: 9
+        task_timesteps: 1
+    lr: 0.0001
+    plateau_factor: 0.2
+    plateau_patience: 2
+    plateau_min_lr: 0
+    plateau_cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/sentinel2_vessel_attribute/dataset_v1/20250205/
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+        dtype: FLOAT32
+      info:
+        data_type: "vector"
+        layers: ["info"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslearn.train.tasks.classification.ClassificationTask
+            init_args:
+              property_name: "type"
+              allow_invalid: true
+              classes: ["cargo", "tanker", "passenger", "service", "tug", "pleasure", "fishing", "enforcement", "sar"]
+              metric_kwargs:
+                average: "micro"
+        input_mapping:
+          eval_task:
+            info: "targets"
+    batch_size: 32
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "classify"
+            task_name: "sentinel2_vessel_type"
+            task_channels: 9
+            task_timesteps: 1
+    train_config:
+      tags:
+        olmoearth_evals_split: "train"
+    val_config:
+      tags:
+        olmoearth_evals_split: "val"
+    test_config:
+      tags:
+        olmoearth_evals_split: "test"
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/accuracy
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/sentinel2_vessels.yaml
+++ b/data/helios_v3/tasks/sentinel2_vessels.yaml
@@ -1,0 +1,117 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel2"]
+        task_type: "detect"
+        task_name: "sentinel2_vessels"
+        task_channels: 2
+        task_timesteps: 1
+    lr: 0.0001
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 1e-6
+        cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/sentinel2_vessels/dataset_v1/20250213/
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: INT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslearn.train.tasks.detection.DetectionTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "vessel"]
+              box_size: 15
+              remap_values: [[0, 1], [0, 255]]
+              exclude_by_center: true
+              enable_map_metric: false
+              enable_f1_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95]]
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          eval_task:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2"]
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "detect"
+            task_name: "sentinel2_vessels"
+            task_channels: 2
+            task_timesteps: 1
+    train_config:
+      patch_size: 128
+      tags:
+        olmoearth_evals_split: train
+      sampler:
+        class_path: rslearn.train.dataset.RandomSamplerFactory
+        init_args:
+          replacement: true
+          num_samples: 131072
+    val_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: val
+    test_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: test
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/F1
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/solar_farm_base.yaml
+++ b/data/helios_v3/tasks/solar_farm_base.yaml
@@ -1,0 +1,111 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel2"]
+        task_type: "segment"
+        task_name: "solar_farm"
+        task_channels: 2
+        task_timesteps: 1
+    lr: 0.0001
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 0
+        cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/solar_farm/dataset_v1/20250605/
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "raster"
+        layers: ["label_raster"]
+        bands: ["label"]
+        dtype: INT32
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslearn.train.tasks.segmentation.SegmentationTask
+            init_args:
+              num_classes: 2
+              metric_kwargs:
+                average: "micro"
+              enable_f1_metric: true
+              enable_miou_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]]
+              remap_values: [[0, 1], [0, 255]]
+        input_mapping:
+          eval_task:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2"]
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "segment"
+            task_name: "solar_farm"
+            task_channels: 2
+            task_timesteps: 1
+    train_config:
+      patch_size: 128
+      tags:
+        olmoearth_evals_split: train
+      # There are many validation patches due to the small patch size, so we set random
+      # sampler to increase the training epoch size to compensate.
+      sampler:
+        class_path: rslearn.train.dataset.RandomSamplerFactory
+        init_args:
+          replacement: true
+          num_samples: 16384
+    val_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: val
+    test_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: test
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/accuracy
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/solar_farm_mm.yaml
+++ b/data/helios_v3/tasks/solar_farm_mm.yaml
@@ -1,0 +1,52 @@
+model:
+  init_args:
+    model:
+      init_args:
+        input_modalities: ["sentinel2", "sentinel1"]
+        task_timesteps: 4
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3", "sentinel2.4", "sentinel2.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      sentinel1:
+        data_type: "raster"
+        layers: ["sentinel1_ascending", "sentinel1_ascending.1", "sentinel1_ascending.2", "sentinel1_ascending.3", "sentinel1_ascending.4", "sentinel1_ascending.5"]
+        bands: ["vv", "vh"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "raster"
+        layers: ["label_raster"]
+        bands: ["label"]
+        dtype: INT32
+        is_target: true
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.sentinel1.Sentinel1ToDecibels
+          init_args:
+            selectors: ["sentinel1"]
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2", "sentinel1"]
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2", "sentinel1"]
+            task_type: "segment"
+            task_name: "solar_farm"
+            task_channels: 2
+            task_timesteps: 4

--- a/data/helios_v3/tasks/solar_farm_ts.yaml
+++ b/data/helios_v3/tasks/solar_farm_ts.yaml
@@ -1,0 +1,41 @@
+model:
+  init_args:
+    model:
+      init_args:
+        task_timesteps: 4
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3", "sentinel2.4", "sentinel2.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "raster"
+        layers: ["label_raster"]
+        bands: ["label"]
+        dtype: INT32
+        is_target: true
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2"]
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "segment"
+            task_name: "solar_farm"
+            task_channels: 2
+            task_timesteps: 4

--- a/data/helios_v3/tasks/wind_turbine_base.yaml
+++ b/data/helios_v3/tasks/wind_turbine_base.yaml
@@ -1,0 +1,120 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterModel
+      init_args:
+        input_size: 128
+        input_modalities: ["sentinel2"]
+        task_type: "detect"
+        task_name: "wind_turbine"
+        task_channels: 2
+        task_timesteps: 1
+    lr: 0.0001
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 0
+        cooldown: 20
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/wind_turbine/dataset_v1/20250605/
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+        passthrough: true
+        dtype: FLOAT32
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          eval_task:
+            class_path: rslearn.train.tasks.detection.DetectionTask
+            init_args:
+              property_name: "category"
+              classes: ["unknown", "turbine"]
+              box_size: 15
+              remap_values: [[0, 1], [0, 255]]
+              exclude_by_center: true
+              enable_map_metric: false
+              enable_f1_metric: true
+              f1_metric_thresholds: [[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95]]
+              f1_metric_kwargs:
+                cmp_mode: "distance"
+                cmp_threshold: 15
+                flatten_classes: true
+        input_mapping:
+          eval_task:
+            targets: "targets"
+    batch_size: 8
+    num_workers: 16
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2"]
+        # This is for Faster R-CNN head to know the image size.
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "detect"
+            task_name: "wind_turbine"
+            task_channels: 2
+            task_timesteps: 1
+    train_config:
+      patch_size: 128
+      tags:
+        olmoearth_evals_split: train
+      # There are many validation patches due to the small patch size, so we set random
+      # sampler to increase the training epoch size to compensate.
+      sampler:
+        class_path: rslearn.train.dataset.RandomSamplerFactory
+        init_args:
+          replacement: true
+          num_samples: 65536
+    val_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: val
+    test_config:
+      patch_size: 128
+      load_all_patches: true
+      tags:
+        olmoearth_evals_split: test
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_top_k: 1
+        save_last: true
+        monitor: val_eval_task/F1
+        mode: max
+rslp_project: placeholder
+rslp_experiment: placeholder

--- a/data/helios_v3/tasks/wind_turbine_mm.yaml
+++ b/data/helios_v3/tasks/wind_turbine_mm.yaml
@@ -1,0 +1,56 @@
+model:
+  init_args:
+    model:
+      init_args:
+        input_modalities: ["sentinel2", "sentinel1"]
+        task_timesteps: 6
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3", "sentinel2.4", "sentinel2.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      sentinel1:
+        data_type: "raster"
+        layers: ["sentinel1_ascending", "sentinel1_ascending.1", "sentinel1_ascending.2", "sentinel1_ascending.3", "sentinel1_ascending.4", "sentinel1_ascending.5"]
+        bands: ["vv", "vh"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    default_config:
+      transforms:
+        - class_path: rslearn.train.transforms.sentinel1.Sentinel1ToDecibels
+          init_args:
+            selectors: ["sentinel1"]
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2", "sentinel1"]
+        # This is for Faster R-CNN head to know the image size.
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2", "sentinel1"]
+            task_type: "detect"
+            task_name: "wind_turbine"
+            task_channels: 2
+            task_timesteps: 6

--- a/data/helios_v3/tasks/wind_turbine_ts.yaml
+++ b/data/helios_v3/tasks/wind_turbine_ts.yaml
@@ -1,0 +1,45 @@
+model:
+  init_args:
+    model:
+      init_args:
+        task_timesteps: 6
+data:
+  init_args:
+    inputs:
+      sentinel2:
+        data_type: "raster"
+        layers: ["sentinel2", "sentinel2.1", "sentinel2.2", "sentinel2.3", "sentinel2.4", "sentinel2.5"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+      mask:
+        data_type: "raster"
+        layers: ["mask"]
+        bands: ["mask"]
+        passthrough: true
+        dtype: FLOAT32
+        is_target: true
+      targets:
+        data_type: "vector"
+        layers: ["label"]
+        is_target: true
+    default_config:
+      transforms:
+        - class_path: rslp.transforms.mask.Mask
+          init_args:
+            selectors: ["sentinel2"]
+        # This is for Faster R-CNN head to know the image size.
+        - class_path: rslearn.train.transforms.concatenate.Concatenate
+          init_args:
+            selections:
+              sentinel2: []
+            output_selector: image
+        - class_path: rslp.olmoearth_evals.eval_adapter.EvalAdapterNormalize
+          init_args:
+            input_size: 128
+            input_modalities: ["sentinel2"]
+            task_type: "detect"
+            task_name: "wind_turbine"
+            task_channels: 2
+            task_timesteps: 6

--- a/rslp/common/beaker_train.py
+++ b/rslp/common/beaker_train.py
@@ -42,6 +42,7 @@ def beaker_train(
     extra_args: list[str] = [],
     priority: str = "high",
     retries: int = 0,
+    extra_env_vars: dict[str, str] = {},
 ) -> None:
     """Launch training for the specified config on Beaker.
 
@@ -67,6 +68,7 @@ def beaker_train(
         extra_args: extra arguments to pass in the Beaker job.
         priority: the priority to assign to the Beaker job.
         retries: how many times to retry the Beaker job.
+        extra_env_vars: additional environment variables to set in the Beaker job.
     """
     # Normalize the config_path / config_paths option to always get a config_paths list
     # (so if config_path is set, make a one-element list from it).
@@ -140,6 +142,14 @@ def beaker_train(
                     BeakerEnvVar(
                         name="WANDB_USERNAME",
                         value=username,
+                    )
+                )
+
+            for env_name, env_value in extra_env_vars.items():
+                env_vars.append(
+                    BeakerEnvVar(
+                        name=env_name,
+                        value=env_value,
                     )
                 )
 

--- a/rslp/helios/norm.py
+++ b/rslp/helios/norm.py
@@ -4,7 +4,6 @@ import json
 from typing import Any
 
 from helios.data.normalize import load_computed_config
-from helios.data.utils import convert_to_db
 from rslearn.train.transforms.transform import Transform
 
 from rslp.log_utils import get_logger
@@ -13,7 +12,11 @@ logger = get_logger(__file__)
 
 
 class HeliosNormalize(Transform):
-    """Normalize using Helios JSON config."""
+    """Normalize using Helios JSON config.
+
+    For Sentinel-1 data, the values should be converted to decibels before being passed
+    to this transform.
+    """
 
     def __init__(
         self,
@@ -60,8 +63,6 @@ class HeliosNormalize(Transform):
         for modality_name, cur_band_names in self.band_names.items():
             band_norms = self.norm_config[modality_name]
             image = input_dict[modality_name]
-            if modality_name == "sentinel1":
-                image = convert_to_db(image)
             # Keep a set of indices to make sure that we normalize all of them.
             needed_band_indices = set(range(image.shape[0]))
             num_timesteps = image.shape[0] // len(cur_band_names)

--- a/rslp/olmoearth_evals/__init__.py
+++ b/rslp/olmoearth_evals/__init__.py
@@ -1,0 +1,1 @@
+"""Adapter for evaluation tasks."""

--- a/rslp/olmoearth_evals/anysat.py
+++ b/rslp/olmoearth_evals/anysat.py
@@ -1,0 +1,217 @@
+"""Evaluation adapter for AnySat."""
+
+import torch
+from rslearn.models.anysat import AnySat
+from rslearn.models.conv import Conv
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pick_features import PickFeatures
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.normalize import Normalize
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.nandi.train import SegmentationPoolingDecoder
+
+from .constants import LANDSAT_BANDS, SENTINEL1_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate AnySat model."""
+    output_mode = "dense"
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                Conv(
+                    in_channels=1536,
+                    out_channels=task_channels,
+                    kernel_size=1,
+                    activation=torch.nn.Identity(),
+                ),
+                PickFeatures(
+                    indexes=[0],
+                    collapse=True,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                SegmentationPoolingDecoder(
+                    in_channels=1536,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                FasterRCNN(
+                    downsample_factors=[4],
+                    num_channels=768,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                )
+            ]
+        )
+        output_mode = "patch"
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+        output_mode = "patch"
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+        output_mode = "patch"
+    else:
+        raise NotImplementedError
+
+    modalities = []
+    for modality in input_modalities:
+        if modality == "sentinel2":
+            modalities.append("s2")
+        elif modality == "sentinel1":
+            modalities.append("s1-asc")
+        elif modality == "landsat":
+            modalities.append("l8")
+        else:
+            raise ValueError(f"unsupported modality {modality}")
+
+    dates = list(range(0, 30 * task_timesteps, 30))
+
+    return MultiTaskModel(
+        encoder=[
+            AnySat(
+                modalities=modalities,
+                patch_size_meters=40,
+                output=output_mode,
+                dates={modality: dates for modality in modalities},
+                output_modality=modalities[0],
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate AnySat transform."""
+    modules: list[torch.nn.Module] = []
+
+    if "sentinel2" in input_modalities:
+        wanted_bands = [
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B11",
+            "B12",
+        ]
+        band_indices = [SENTINEL2_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="s2",
+            )
+        )
+        modules.append(
+            Normalize(
+                mean=2000,
+                std=1500,
+                selectors=["s2"],
+            )
+        )
+
+    if "sentinel1" in input_modalities:
+        wanted_bands = ["vv", "vh"]
+        band_indices = [SENTINEL1_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(SENTINEL1_BANDS),
+                input_selector="sentinel1",
+                output_selector="s1-asc",
+            )
+        )
+        modules.append(
+            Normalize(
+                mean=-10,
+                std=10,
+                selectors=["s1-asc"],
+            )
+        )
+
+    if "landsat" in input_modalities:
+        wanted_bands = [
+            "B8",
+            "B1",
+            "B2",
+            "B3",
+            "B4",
+            "B5",
+            "B6",
+            "B7",
+            "B9",
+            "B10",
+            "B11",
+        ]
+        band_indices = [LANDSAT_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(LANDSAT_BANDS),
+                input_selector="landsat",
+                output_selector="l8",
+            )
+        )
+        modules.append(
+            Normalize(
+                mean=10000,
+                std=8000,
+                selectors=["l8"],
+            )
+        )
+
+    return Sequential(*modules)

--- a/rslp/olmoearth_evals/assign_split.py
+++ b/rslp/olmoearth_evals/assign_split.py
@@ -1,0 +1,39 @@
+"""Assign train/val/test split."""
+
+import hashlib
+import multiprocessing
+import sys
+
+import tqdm
+from rslearn.dataset import Dataset, Window
+from upath import UPath
+
+
+def assign_split(window: Window) -> None:
+    """Assign split of the window to train, val, or test.
+
+    We split based on a 1024x1024 pixel grid so the train windows are not too close to
+    the validation and test windows. We assign 1/4 val, 1/4 test, and 1/2 train.
+    """
+    tile = (window.bounds[0] // 1024, window.bounds[1] // 1024)
+    grid_cell_id = f"{window.projection.crs}_{tile[0]}_{tile[1]}"
+    first_hex_char_in_hash = hashlib.sha256(grid_cell_id.encode()).hexdigest()[0]
+    if first_hex_char_in_hash in ["0", "1", "2", "3"]:
+        split = "val"
+    elif first_hex_char_in_hash in ["4", "5", "6", "7"]:
+        split = "test"
+    else:
+        split = "train"
+    window.options["olmoearth_evals_split"] = split
+    window.save()
+
+
+if __name__ == "__main__":
+    ds_path = UPath(sys.argv[1])
+    multiprocessing.set_start_method("forkserver")
+    windows = Dataset(ds_path).load_windows(workers=128, show_progress=True)
+    p = multiprocessing.Pool(128)
+    outputs = p.imap_unordered(assign_split, windows)
+    for _ in tqdm.tqdm(outputs, total=len(windows)):
+        pass
+    p.close()

--- a/rslp/olmoearth_evals/assign_split_sentinel2_vessel_attribute.py
+++ b/rslp/olmoearth_evals/assign_split_sentinel2_vessel_attribute.py
@@ -1,0 +1,52 @@
+"""Assign train/val/test split."""
+
+import hashlib
+import multiprocessing
+import sys
+
+import tqdm
+from rslearn.dataset import Dataset, Window
+from rslearn.utils.vector_format import GeojsonVectorFormat
+from upath import UPath
+
+
+def assign_split(window: Window) -> None:
+    """Assign split of the window to train, val, or test.
+
+    This is specialized for vessel attribute prediction to only set the split for
+    windows where length and type are both known.
+    """
+    print(window.path, "get feat")
+    features = GeojsonVectorFormat().decode_vector(
+        window.get_layer_dir("info"), window.projection, window.bounds
+    )
+    assert len(features) == 1
+    feat = features[0]
+
+    print(window.path, "compute split")
+    tile = (window.bounds[0] // 1024, window.bounds[1] // 1024)
+    grid_cell_id = f"{window.projection.crs}_{tile[0]}_{tile[1]}"
+    first_hex_char_in_hash = hashlib.sha256(grid_cell_id.encode()).hexdigest()[0]
+    if "length" not in feat.properties or "type" not in feat.properties:
+        split = "unused"
+    if first_hex_char_in_hash in ["0", "1", "2", "3"]:
+        split = "val"
+    elif first_hex_char_in_hash in ["4", "5", "6", "7"]:
+        split = "test"
+    else:
+        split = "train"
+    window.options["olmoearth_evals_split"] = split
+    print(window.path, "saving")
+    window.save()
+    print(window.path, "done")
+
+
+if __name__ == "__main__":
+    ds_path = UPath(sys.argv[1])
+    multiprocessing.set_start_method("forkserver")
+    windows = Dataset(ds_path).load_windows(workers=128, show_progress=True)
+    p = multiprocessing.Pool(128)
+    outputs = p.imap_unordered(assign_split, windows)
+    for _ in tqdm.tqdm(outputs, total=len(windows)):
+        pass
+    p.close()

--- a/rslp/olmoearth_evals/clay.py
+++ b/rslp/olmoearth_evals/clay.py
@@ -1,0 +1,180 @@
+"""Evaluation adapter for Clay."""
+
+import torch
+from rslearn.models.clay.clay import Clay, ClayNormalize, ClaySize
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.simple_time_series import SimpleTimeSeries
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.nandi.train import SegmentationPoolingDecoder
+
+from .constants import LANDSAT_BANDS, SENTINEL1_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Clay model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                UNetDecoder(
+                    in_channels=[[8, 1024]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                    num_channels={8: 512, 4: 512, 2: 256, 1: 128},
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                SegmentationPoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                FasterRCNN(
+                    downsample_factors=[8],
+                    num_channels=1024,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                )
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    if len(input_modalities) != 1:
+        raise ValueError("Clay only supports one input modality at a time")
+
+    input_modality = input_modalities[0]
+    image_keys = {}
+    if input_modality == "sentinel2":
+        clay_modality = "sentinel-2-l2a"
+        image_keys[clay_modality] = 10
+    elif input_modality == "sentinel1":
+        clay_modality = "sentinel-1-rtc"
+        image_keys[clay_modality] = 2
+    elif input_modality == "landsat":
+        clay_modality = "landsat-c2l1"
+        image_keys[clay_modality] = 6
+
+    return MultiTaskModel(
+        encoder=[
+            SimpleTimeSeries(
+                encoder=Clay(
+                    model_size=ClaySize.LARGE,
+                    modality=clay_modality,
+                ),
+                image_keys=image_keys,
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Clay transform."""
+    modules: list[torch.nn.Module] = []
+
+    if "sentinel2" in input_modalities:
+        wanted_sentinel2 = [
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B11",
+            "B12",
+        ]
+        sentinel2_indexes = [SENTINEL2_BANDS.index(band) for band in wanted_sentinel2]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel2_indexes,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="sentinel-2-l2a",
+            ),
+        )
+
+    if "landsat" in input_modalities:
+        # In metadata.yaml it says red, green, blue, nir08, swir16, swir22.
+        wanted_landsat = ["B4", "B3", "B2", "B5", "B6", "B7"]
+        landsat_indexes = [LANDSAT_BANDS.index(band) for band in wanted_landsat]
+        modules.append(
+            SelectBands(
+                band_indices=landsat_indexes,
+                num_bands_per_timestep=len(LANDSAT_BANDS),
+                input_selector="landsat",
+                output_selector="landsat-c2l1",
+            ),
+        )
+
+    if "sentinel1" in input_modalities:
+        wanted_sentinel1 = ["vv", "vh"]
+        sentinel1_indexes = [SENTINEL1_BANDS.index(band) for band in wanted_sentinel1]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel1_indexes,
+                num_bands_per_timestep=len(SENTINEL1_BANDS),
+                input_selector="sentinel1",
+                output_selector="sentinel-1-rtc",
+            ),
+        )
+
+    modules.append(ClayNormalize())
+
+    return Sequential(*modules)

--- a/rslp/olmoearth_evals/constants.py
+++ b/rslp/olmoearth_evals/constants.py
@@ -1,0 +1,19 @@
+"""Constants for the evaluation adapter."""
+
+# The input to the evaluation adapter transform must correspond to these bands.
+SENTINEL2_BANDS = [
+    "B01",
+    "B02",
+    "B03",
+    "B04",
+    "B05",
+    "B06",
+    "B07",
+    "B08",
+    "B8A",
+    "B09",
+    "B11",
+    "B12",
+]
+LANDSAT_BANDS = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11"]
+SENTINEL1_BANDS = ["vv", "vh"]

--- a/rslp/olmoearth_evals/copernicusfm.py
+++ b/rslp/olmoearth_evals/copernicusfm.py
@@ -1,0 +1,176 @@
+"""Evaluation adapter for Copernicus-FM."""
+
+import torch
+from rslearn.models.copernicusfm import CopernicusFM
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.resize_features import ResizeFeatures
+from rslearn.models.simple_time_series import SimpleTimeSeries
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.nandi.train import SegmentationPoolingDecoder
+
+from .constants import SENTINEL1_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Copernicus-FM model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                UNetDecoder(
+                    in_channels=[[16, 768]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                    num_channels={8: 512, 4: 512, 2: 256, 1: 128},
+                    original_size_to_interpolate=[input_size, input_size],
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                SegmentationPoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                ResizeFeatures(out_sizes=[(input_size // 16, input_size // 16)]),
+                FasterRCNN(
+                    downsample_factors=[16],
+                    num_channels=768,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                ),
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    band_order: dict = {}
+    image_keys: dict = {}
+    for modality in input_modalities:
+        if modality == "sentinel2":
+            if task_name == "pastis":
+                # PASTIS is missing some bands and Copernicus-FM can deal with this.
+                band_order["sentinel2_l2a"] = [
+                    "B02",
+                    "B03",
+                    "B04",
+                    "B05",
+                    "B06",
+                    "B07",
+                    "B08",
+                    "B8A",
+                    "B11",
+                    "B12",
+                ]
+                image_keys["sentinel2_l2a"] = 10
+            else:
+                band_order["sentinel2_l2a"] = SENTINEL2_BANDS
+                image_keys["sentinel2_l2a"] = len(SENTINEL2_BANDS)
+        elif modality == "sentinel1":
+            band_order["sentinel1"] = SENTINEL1_BANDS
+            image_keys["sentinel1"] = len(SENTINEL1_BANDS)
+        else:
+            raise ValueError(f"unsupported modality {modality}")
+
+    return MultiTaskModel(
+        encoder=[
+            SimpleTimeSeries(
+                CopernicusFM(
+                    band_order=band_order,
+                ),
+                image_keys=image_keys,
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Copernicus-FM transform."""
+    modules: list[torch.nn.Module] = []
+
+    # Rename sentinel2 to sentinel2_l2a.
+    if "sentinel2" in input_modalities:
+        if task_name == "pastis":
+            wanted_bands = [
+                "B02",
+                "B03",
+                "B04",
+                "B05",
+                "B06",
+                "B07",
+                "B08",
+                "B8A",
+                "B11",
+                "B12",
+            ]
+        else:
+            wanted_bands = SENTINEL2_BANDS
+
+        band_indices = [SENTINEL2_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="sentinel2_l2a",
+            )
+        )
+
+    if len(modules) == 0:
+        return torch.nn.Identity()
+    else:
+        return Sequential(*modules)

--- a/rslp/olmoearth_evals/croma.py
+++ b/rslp/olmoearth_evals/croma.py
@@ -1,0 +1,169 @@
+"""Evaluation adapter for CROMA."""
+
+import torch
+from rslearn.models.croma import Croma, CromaModality, CromaNormalize, CromaSize
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.simple_time_series import SimpleTimeSeries
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.nandi.train import SegmentationPoolingDecoder
+
+from .constants import SENTINEL1_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate CROMA model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                UNetDecoder(
+                    in_channels=[[8, 768]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                    num_channels={8: 512, 4: 512, 2: 256, 1: 128},
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                SegmentationPoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                FasterRCNN(
+                    downsample_factors=[8],
+                    num_channels=768,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                )
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    modality: CromaModality
+    image_keys = {}
+    if input_modalities == ["sentinel2"]:
+        modality = CromaModality.SENTINEL2
+        image_keys["sentinel2"] = 12
+    elif input_modalities == ["sentinel1"]:
+        modality = CromaModality.SENTINEL1
+        image_keys["sentinel1"] = 2
+    elif set(input_modalities) == {"sentinel1", "sentinel2"}:
+        modality = CromaModality.BOTH
+        image_keys["sentinel2"] = 12
+        image_keys["sentinel1"] = 2
+    else:
+        raise NotImplementedError
+
+    return MultiTaskModel(
+        encoder=[
+            SimpleTimeSeries(
+                encoder=Croma(
+                    size=CromaSize.BASE,
+                    modality=modality,
+                    image_resolution=input_size,
+                ),
+                image_keys=image_keys,
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate CROMA transform."""
+    modules: list[torch.nn.Module] = []
+
+    if "sentinel2" in input_modalities:
+        wanted_bands = [
+            "B01",
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B09",
+            "B11",
+            "B12",
+        ]
+        band_indices = [SENTINEL2_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="sentinel2",
+            )
+        )
+
+    if "sentinel1" in input_modalities:
+        wanted_bands = ["vv", "vh"]
+        band_indices = [SENTINEL1_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(SENTINEL1_BANDS),
+                input_selector="sentinel1",
+                output_selector="sentinel1",
+            )
+        )
+
+    modules.append(CromaNormalize())
+    return Sequential(*modules)

--- a/rslp/olmoearth_evals/eval_adapter.py
+++ b/rslp/olmoearth_evals/eval_adapter.py
@@ -1,0 +1,126 @@
+"""Adapter for evaluation tasks."""
+
+import os
+from typing import Any
+
+import torch
+from rslearn.train.transforms.transform import Transform
+
+import rslp.olmoearth_evals.anysat as anysat
+import rslp.olmoearth_evals.clay as clay
+import rslp.olmoearth_evals.copernicusfm as copernicusfm
+import rslp.olmoearth_evals.croma as croma
+import rslp.olmoearth_evals.olmoearth as olmoearth
+import rslp.olmoearth_evals.panopticon as panopticon
+import rslp.olmoearth_evals.presto as presto
+import rslp.olmoearth_evals.prithvi as prithvi
+import rslp.olmoearth_evals.satlaspretrain as satlaspretrain
+import rslp.olmoearth_evals.terramind as terramind
+
+modules_by_model_id = {
+    "clay": clay,
+    "croma": croma,
+    "olmoearth": olmoearth,
+    "panopticon": panopticon,
+    "presto": presto,
+    "prithvi": prithvi,
+    "satlaspretrain": satlaspretrain,
+    "terramind": terramind,
+    "copernicusfm": copernicusfm,
+    "anysat": anysat,
+    # dinov3
+}
+
+
+class EvalAdapterModel(torch.nn.Module):
+    """Adapter model for evaluation tasks in the OlmoEarth model paper.
+
+    This model provides a common interface to OlmoEarth and several baselines. It is
+    only intended to be used for specific evaluation tasks, since it does not afford
+    flexibility for fine-grained customization that the model config normally provides.
+
+    It also has lots of hardcoded constants for checkpoints. It is really just for
+    internal Ai2 use.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        input_modalities: list[str],
+        task_type: str,
+        task_name: str,
+        task_channels: int = 1,
+        task_timesteps: int = 1,
+    ):
+        """Create a new EvalAdapterModel.
+
+        Args:
+            input_size: height and width of the input in pixels.
+            input_modalities: subset of ["sentinel2", "sentinel1", "landsat"].
+            task_type: either "segment", "segment_small", "regress", or "detect".
+            task_name: the name of the task, like "pastis".
+            task_channels: how many output channels there are. For example, this is the
+                number of classes for segmentation and detection tasks. For regression,
+                it should be 1 which is also the default value.
+            task_timesteps: number of input timesteps.
+        """
+        super().__init__()
+        model_id = os.environ["EVAL_ADAPTER_MODEL_ID"]
+        self.model = modules_by_model_id[model_id].get_model(
+            input_size=input_size,
+            input_modalities=input_modalities,
+            task_type=task_type,
+            task_name=task_name,
+            task_channels=task_channels,
+            task_timesteps=task_timesteps,
+        )
+
+    def forward(
+        self,
+        inputs: list[dict[str, Any]],
+        targets: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Apply the sequence of modules on the inputs, including shared trunk.
+
+        Args:
+            inputs: list of input dicts
+            targets: optional list of target dicts
+
+        Returns:
+            dict with keys "outputs" and "loss_dict".
+        """
+        return self.model(inputs, targets)
+
+
+class EvalAdapterNormalize(Transform):
+    """Normalization for evaluation tasks."""
+
+    def __init__(
+        self,
+        input_size: int,
+        input_modalities: list[str],
+        task_type: str,
+        task_name: str,
+        task_channels: int = 1,
+        task_timesteps: int = 1,
+    ):
+        """Create a new EvalAdapterNormalize.
+
+        This has the same arguments as EvalAdapterModel.
+        """
+        super().__init__()
+        model_id = os.environ["EVAL_ADAPTER_MODEL_ID"]
+        self.transform = modules_by_model_id[model_id].get_transform(
+            input_size=input_size,
+            input_modalities=input_modalities,
+            task_type=task_type,
+            task_name=task_name,
+            task_channels=task_channels,
+            task_timesteps=task_timesteps,
+        )
+
+    def forward(
+        self, input_dict: dict[str, Any], target_dict: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Normalize the input_dict."""
+        return self.transform(input_dict, target_dict)

--- a/rslp/olmoearth_evals/olmoearth.py
+++ b/rslp/olmoearth_evals/olmoearth.py
@@ -1,0 +1,186 @@
+"""Evaluation adapter for OlmoEarth."""
+
+import torch
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.helios.model import Helios
+from rslp.helios.norm import HeliosNormalize
+from rslp.nandi.train import SegmentationPoolingDecoder
+
+from .constants import LANDSAT_BANDS, SENTINEL1_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate OlmoEarth model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                UNetDecoder(
+                    in_channels=[[4, 768]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                    num_channels={4: 512, 2: 256, 1: 128},
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                SegmentationPoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                FasterRCNN(
+                    downsample_factors=[4],
+                    num_channels=768,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                )
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    return MultiTaskModel(
+        encoder=[
+            Helios(
+                checkpoint_path="/weka/dfive-default/helios/checkpoints/henryh/base_v6.1_add_chm_cdl_worldcereal/step500000",
+                selector=["encoder"],
+                forward_kwargs=dict(patch_size=4),
+                patch_size=4,
+                embedding_size=768,
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate OlmoEarth transform."""
+    modules: list[torch.nn.Module] = []
+    band_names: dict = {}
+
+    if "sentinel2" in input_modalities:
+        wanted_sentinel2 = [
+            "B02",
+            "B03",
+            "B04",
+            "B08",
+            "B05",
+            "B06",
+            "B07",
+            "B8A",
+            "B11",
+            "B12",
+            "B01",
+            "B09",
+        ]
+        sentinel2_indexes = [SENTINEL2_BANDS.index(band) for band in wanted_sentinel2]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel2_indexes,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="sentinel2_l2a",
+            ),
+        )
+        band_names["sentinel2_l2a"] = wanted_sentinel2
+
+    if "landsat" in input_modalities:
+        wanted_landsat = [
+            "B8",
+            "B1",
+            "B2",
+            "B3",
+            "B4",
+            "B5",
+            "B6",
+            "B7",
+            "B9",
+            "B10",
+            "B11",
+        ]
+        landsat_indexes = [LANDSAT_BANDS.index(band) for band in wanted_landsat]
+        modules.append(
+            SelectBands(
+                band_indices=landsat_indexes,
+                num_bands_per_timestep=len(LANDSAT_BANDS),
+                input_selector="landsat",
+                output_selector="landsat",
+            ),
+        )
+        band_names["landsat"] = wanted_landsat
+
+    if "sentinel1" in input_modalities:
+        wanted_sentinel1 = ["vv", "vh"]
+        sentinel1_indexes = [SENTINEL1_BANDS.index(band) for band in wanted_sentinel1]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel1_indexes,
+                num_bands_per_timestep=len(SENTINEL1_BANDS),
+                input_selector="sentinel1",
+                output_selector="sentinel1",
+            ),
+        )
+        band_names["sentinel1"] = wanted_sentinel1
+
+    modules.append(
+        HeliosNormalize(
+            band_names=band_names,
+        )
+    )
+
+    return Sequential(*modules)

--- a/rslp/olmoearth_evals/panopticon.py
+++ b/rslp/olmoearth_evals/panopticon.py
@@ -1,0 +1,208 @@
+"""Evaluation adapter for Panopticon."""
+
+import torch
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.panopticon import Panopticon
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.simple_time_series import SimpleTimeSeries
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.concatenate import Concatenate
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.nandi.train import SegmentationPoolingDecoder
+
+from .constants import SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Panopticon model."""
+    # Panopticon resizes to 256x256 and always has 16x16 output feature map.
+    downsample_factor = input_size // 16
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                UNetDecoder(
+                    in_channels=[[downsample_factor, 768]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                    num_channels={8: 512, 4: 512, 2: 256, 1: 128},
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                SegmentationPoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                FasterRCNN(
+                    downsample_factors=[downsample_factor],
+                    num_channels=768,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                )
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    band_order: dict = {}
+    image_keys: dict = {}
+    for modality in input_modalities:
+        if modality == "sentinel2":
+            if task_name == "pastis":
+                # PASTIS is missing some bands and Panopticon can deal with this.
+                band_order["sentinel2"] = [
+                    "B02",
+                    "B03",
+                    "B04",
+                    "B05",
+                    "B06",
+                    "B07",
+                    "B08",
+                    "B8A",
+                    "B11",
+                    "B12",
+                ]
+                image_keys["sentinel2"] = 10
+            else:
+                band_order["sentinel2"] = [
+                    "B01",
+                    "B02",
+                    "B03",
+                    "B04",
+                    "B05",
+                    "B06",
+                    "B07",
+                    "B08",
+                    "B8A",
+                    "B09",
+                    "B11",
+                    "B12",
+                ]
+                image_keys["sentinel2"] = 12
+        elif modality == "sentinel1":
+            band_order["sentinel1"] = ["VV", "VH"]
+            image_keys["sentinel1"] = 2
+        elif modality == "landsat":
+            band_order["landsat8"] = [
+                "B1",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "B10",
+                "B11",
+            ]
+            image_keys["landsat8"] = 11
+
+    return MultiTaskModel(
+        encoder=[
+            SimpleTimeSeries(
+                encoder=Panopticon(
+                    band_order=band_order,
+                ),
+                image_keys=image_keys,
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Panopticon transform."""
+    modules: list[torch.nn.Module] = []
+
+    # Rename landsat to landsat8 if it is present.
+    if "landsat" in input_modalities:
+        modules.append(
+            Concatenate(
+                selections={"landsat": []},
+                output_selector="landsat8",
+            )
+        )
+
+    # Sub-select Sentinel-2 bands for PASTIS.
+    # Otherwise we can keep sentinel2 as is.
+    if task_name == "pastis" and "sentinel2" in input_modalities:
+        wanted_bands = [
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B11",
+            "B12",
+        ]
+        band_indices = [SENTINEL2_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="sentinel2",
+            )
+        )
+
+    if len(modules) == 0:
+        return torch.nn.Identity()
+    else:
+        return Sequential(*modules)

--- a/rslp/olmoearth_evals/presto.py
+++ b/rslp/olmoearth_evals/presto.py
@@ -1,0 +1,155 @@
+"""Evaluation adapter for Presto."""
+
+import torch
+from rslearn.models.conv import Conv
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pick_features import PickFeatures
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.presto import Presto
+from rslearn.models.resize_features import ResizeFeatures
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.select_bands import SelectBands
+
+from .constants import SENTINEL1_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Presto model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                Conv(
+                    in_channels=128,
+                    out_channels=task_channels,
+                    kernel_size=1,
+                    activation=torch.nn.Identity(),
+                ),
+                PickFeatures(
+                    indexes=[0],
+                    collapse=True,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                Conv(
+                    in_channels=128,
+                    out_channels=task_channels,
+                    kernel_size=1,
+                    activation=torch.nn.Identity(),
+                ),
+                PickFeatures(
+                    indexes=[0],
+                    collapse=True,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                ResizeFeatures(out_sizes=[(input_size // 4, input_size // 4)]),
+                FasterRCNN(
+                    downsample_factors=[4],
+                    num_channels=128,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                ),
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=128,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=128,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    return MultiTaskModel(
+        encoder=[Presto(pixel_batch_size=16384)],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Presto transform."""
+    modules: list[torch.nn.Module] = []
+
+    if "sentinel2" in input_modalities:
+        # Rename to s2 and pick different bands.
+        # Presto doesn't use B01 or B09.
+        wanted_sentinel2 = [
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B11",
+            "B12",
+        ]
+        sentinel2_indexes = [SENTINEL2_BANDS.index(band) for band in wanted_sentinel2]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel2_indexes,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="s2",
+            )
+        )
+
+    if "sentinel1" in input_modalities:
+        # Rename to s1.
+        wanted_sentinel1 = ["vv", "vh"]
+        sentinel1_indexes = [SENTINEL1_BANDS.index(band) for band in wanted_sentinel1]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel1_indexes,
+                num_bands_per_timestep=len(SENTINEL1_BANDS),
+                input_selector="sentinel1",
+                output_selector="s1",
+            )
+        )
+
+    return Sequential(*modules)

--- a/rslp/olmoearth_evals/prithvi.py
+++ b/rslp/olmoearth_evals/prithvi.py
@@ -1,0 +1,154 @@
+"""Evaluation adapter for CROMA."""
+
+import torch
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pick_features import PickFeatures
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.prithvi import PrithviNormalize, PrithviV2
+from rslearn.models.resize_features import ResizeFeatures
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.concatenate import Concatenate
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.nandi.train import SegmentationPoolingDecoder
+
+from .constants import LANDSAT_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Prithvi model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                PickFeatures(indexes=[10]),
+                UNetDecoder(
+                    in_channels=[[16, 1024]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                    num_channels={8: 512, 4: 512, 2: 256, 1: 128},
+                    original_size_to_interpolate=[input_size, input_size],
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                PickFeatures(indexes=[10]),
+                SegmentationPoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                PickFeatures(indexes=[10]),
+                ResizeFeatures(out_sizes=[(input_size // 16, input_size // 16)]),
+                FasterRCNN(
+                    downsample_factors=[16],
+                    num_channels=1024,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                ),
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    return MultiTaskModel(
+        encoder=[
+            PrithviV2(
+                num_frames=task_timesteps,
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate Prithvi transform."""
+    modules: list[torch.nn.Module] = []
+    concatenate_selections: dict[str, list] = {}
+
+    if "sentinel2" in input_modalities:
+        # We pick Sentinel-2 bands that best correspond to HLS bands 2, 3, 4, 5, 6, 7.
+        # Ideally we would input HLS Sentinel-2 but we don't have that.
+        wanted_bands = ["B02", "B03", "B04", "B08", "B11", "B12"]
+        band_indices = [SENTINEL2_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="sentinel2",
+            )
+        )
+        concatenate_selections["sentinel2"] = []
+
+    if "landsat" in input_modalities:
+        wanted_bands = ["B2", "B3", "B4", "B5", "B6", "B7"]
+        band_indices = [LANDSAT_BANDS.index(band) for band in wanted_bands]
+        modules.append(
+            SelectBands(
+                band_indices=band_indices,
+                num_bands_per_timestep=len(LANDSAT_BANDS),
+                input_selector="landsat",
+                output_selector="landsat",
+            )
+        )
+        concatenate_selections["landsat"] = []
+
+    # We concatenate the Sentinel-2 where we picked HLS-ish bands, and Landsat.
+    # And output the expected "image" key of stacked HLS images.
+    modules.append(
+        Concatenate(selections=concatenate_selections, output_selector="image")
+    )
+
+    modules.append(PrithviNormalize())
+    return Sequential(*modules)

--- a/rslp/olmoearth_evals/satlaspretrain.py
+++ b/rslp/olmoearth_evals/satlaspretrain.py
@@ -1,0 +1,162 @@
+"""Evaluation adapter for SatlasPretrain."""
+
+import torch
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.fpn import Fpn
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.simple_time_series import SimpleTimeSeries
+from rslearn.models.swin import Swin
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.normalize import Normalize
+from rslearn.train.transforms.select_bands import SelectBands
+
+from .constants import SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate SatlasPretrain model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                UNetDecoder(
+                    in_channels=[[4, 128], [8, 256], [16, 512], [32, 1024]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        raise NotImplementedError
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                FasterRCNN(
+                    downsample_factors=[4, 8, 16, 32],
+                    num_channels=128,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32], [64], [128], [256]],
+                )
+            ],
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=1024,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    if task_type == "detect":
+        return MultiTaskModel(
+            encoder=[
+                SimpleTimeSeries(
+                    encoder=Swin(
+                        pretrained=False,
+                        input_channels=9,
+                        output_layers=[1, 3, 5, 7],
+                    ),
+                    image_channels=9,
+                ),
+                Fpn(
+                    in_channels=[128, 256, 512, 1024],
+                    out_channels=128,
+                ),
+            ],
+            decoders=decoders,
+        )
+    else:
+        return MultiTaskModel(
+            encoder=[
+                SimpleTimeSeries(
+                    encoder=Swin(
+                        pretrained=False,
+                        input_channels=9,
+                        output_layers=[1, 3, 5, 7],
+                    ),
+                    image_channels=9,
+                ),
+            ],
+            decoders=decoders,
+        )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate SatlasPretrain transform."""
+    if input_modalities != ["sentinel2"]:
+        raise ValueError(
+            "satlaspretrain evaluation is only designed to work with Sentinel-2 input"
+        )
+
+    modules: list[torch.nn.Module] = []
+
+    wanted_bands = ["B04", "B03", "B02", "B05", "B06", "B07", "B08", "B11", "B12"]
+    band_indices = [SENTINEL2_BANDS.index(band) for band in wanted_bands]
+    modules.append(
+        SelectBands(
+            band_indices=band_indices,
+            num_bands_per_timestep=len(SENTINEL2_BANDS),
+            input_selector="sentinel2",
+            output_selector="image",
+        )
+    )
+    # Normalization for RGB bands.
+    modules.append(
+        Normalize(
+            mean=0,
+            std=3000,
+            valid_range=[0, 1],
+            bands=[0, 1, 2],
+            num_bands=9,
+        )
+    )
+    # Normalization for the other bands.
+    modules.append(
+        Normalize(
+            mean=0,
+            std=8160,
+            valid_range=[0, 1],
+            bands=[3, 4, 5, 6, 7, 8],
+            num_bands=9,
+        )
+    )
+
+    return Sequential(*modules)

--- a/rslp/olmoearth_evals/terramind.py
+++ b/rslp/olmoearth_evals/terramind.py
@@ -1,0 +1,163 @@
+"""Evaluation adapter for TerraMind."""
+
+import torch
+from rslearn.models.faster_rcnn import FasterRCNN
+from rslearn.models.multitask import MultiTaskModel
+from rslearn.models.pooling_decoder import PoolingDecoder
+from rslearn.models.simple_time_series import SimpleTimeSeries
+from rslearn.models.terramind import Terramind, TerramindNormalize, TerramindSize
+from rslearn.models.unet import UNetDecoder
+from rslearn.train.tasks.classification import ClassificationHead
+from rslearn.train.tasks.regression import RegressionHead
+from rslearn.train.tasks.segmentation import SegmentationHead
+from rslearn.train.transforms import Sequential
+from rslearn.train.transforms.select_bands import SelectBands
+
+from rslp.crop.kenya_nandi.train import SegmentationPoolingDecoder
+
+from .constants import SENTINEL1_BANDS, SENTINEL2_BANDS
+
+
+def get_model(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate TerraMind model."""
+    if task_type == "segment":
+        decoders = dict(
+            eval_task=[
+                UNetDecoder(
+                    in_channels=[[16, 768]],
+                    out_channels=task_channels,
+                    conv_layers_per_resolution=2,
+                    num_channels={16: 512, 8: 512, 4: 512, 2: 256, 1: 128},
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "segment_small":
+        decoders = dict(
+            eval_task=[
+                SegmentationPoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                ),
+                SegmentationHead(),
+            ]
+        )
+    elif task_type == "detect":
+        decoders = dict(
+            eval_task=[
+                FasterRCNN(
+                    downsample_factors=[16],
+                    num_channels=768,
+                    num_classes=task_channels,
+                    anchor_sizes=[[32]],
+                )
+            ]
+        )
+    elif task_type == "classify":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                ClassificationHead(),
+            ]
+        )
+    elif task_type == "regress":
+        decoders = dict(
+            eval_task=[
+                PoolingDecoder(
+                    in_channels=768,
+                    out_channels=task_channels,
+                    num_conv_layers=1,
+                    num_fc_layers=1,
+                ),
+                RegressionHead(),
+            ]
+        )
+    else:
+        raise NotImplementedError
+
+    modalities = []
+    image_keys = {}
+    if "sentinel2" in input_modalities:
+        modalities.append("S2L2A")
+        image_keys["S2L2A"] = 12
+    if "sentinel1" in input_modalities:
+        modalities.append("S1GRD")
+        image_keys["S1GRD"] = 2
+
+    return MultiTaskModel(
+        encoder=[
+            SimpleTimeSeries(
+                encoder=Terramind(
+                    model_size=TerramindSize.BASE,
+                    modalities=modalities,
+                ),
+                image_keys=image_keys,
+            ),
+        ],
+        decoders=decoders,
+    )
+
+
+def get_transform(
+    input_size: int,
+    input_modalities: list[str],
+    task_type: str,
+    task_name: str,
+    task_channels: int = 1,
+    task_timesteps: int = 1,
+) -> torch.nn.Module:
+    """Get appropriate TerraMind transform."""
+    modules: list[torch.nn.Module] = []
+
+    if "sentinel2" in input_modalities:
+        wanted_sentinel2 = [
+            "B01",
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B09",
+            "B11",
+            "B12",
+        ]
+        sentinel2_indexes = [SENTINEL2_BANDS.index(band) for band in wanted_sentinel2]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel2_indexes,
+                num_bands_per_timestep=len(SENTINEL2_BANDS),
+                input_selector="sentinel2",
+                output_selector="S2L2A",
+            )
+        )
+
+    if "sentinel1" in input_modalities:
+        wanted_sentinel1 = ["vv", "vh"]
+        sentinel1_indexes = [SENTINEL1_BANDS.index(band) for band in wanted_sentinel1]
+        modules.append(
+            SelectBands(
+                band_indices=sentinel1_indexes,
+                num_bands_per_timestep=len(SENTINEL1_BANDS),
+                input_selector="sentinel1",
+                output_selector="S1GRD",
+            )
+        )
+
+    modules.append(TerramindNormalize())
+
+    return Sequential(*modules)


### PR DESCRIPTION
This is code for OlmoEarth fine-tuning evaluations. Because we have 11 baselines and 12 tasks to compare, we want to avoid having to maintain one config per task per baseline (n^2), instead it should just be one per task and one per baseline.

This adds new `rslp.olmoearth_evals` module which provides some extra infrastructure to make all of the models accept a consistent input. For each model, there is some code there to get the model architecture for a given task and output shape, and also to get whatever model-specific normalizations or band re-ordering that might be needed.

Then the `data/helios_v3/tasks/` configs all load data for each task in the same consistent way. An exception is needed for PASTIS since it only has a subset of bands, and some models can input the subset of bands instead of needing imputation, but otherwise it mostly works since most of the tasks are materialized using rslearn.

The launcher is in `data/helios_v3/run.py` and `data/helios_v3/README.md` provides some documentation about it. Also there are model-specific configs but they basically just configure freezing/unfreezing. The model is passed to `rslp.olmoearth_evals.eval_adapter` via environment variable by the launcher.

Also some new code is added to assign splits specifically for this evaluation.