### PR TITLE
Fix unexpanded RSLP_PREFIX in management_dir

### DIFF
--- a/rslp/olmoearth_evals/20260415_evals.md
+++ b/rslp/olmoearth_evals/20260415_evals.md
@@ -2,7 +2,7 @@
 
 Image: `yawenzzzz/rslpomp20260415a`
 Checkpoint: `/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000`
-W&B project: `2026_04_12_v1.1_finetune_partner_tasks`
+W&B project: `2026_04_15_v1.1_finetune_partner_tasks`
 
 Note: all tasks use `use_legacy_timestamps: true` since the checkpoint was trained with legacy timestamps.
 
@@ -14,7 +14,7 @@ python -m rslp.main olmoearth_evals launch \
     --tasks '["forest_loss_driver", "ecosystem", "lfmc_ts", "mangrove_ts", "marine_infra_ts", "nandi_ts", "sentinel2_vessels", "sentinel2_vessel_length", "sentinel2_vessel_type", "solar_farm_ts", "wind_turbine_ts", "awf_ts"]' \
     --prefix 20260415 \
     --image_name yawenzzzz/rslpomp20260415a \
-    --project 2026_04_12_v1.1_finetune_partner_tasks \
+    --project 2026_04_15_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```
 
@@ -26,7 +26,7 @@ python -m rslp.main olmoearth_evals launch \
     --tasks '["awf_mm", "lfmc_mm", "mangrove_mm", "marine_infra_mm", "nandi_mm", "solar_farm_mm", "wind_turbine_mm"]' \
     --prefix 20260415 \
     --image_name yawenzzzz/rslpomp20260415a \
-    --project 2026_04_12_v1.1_finetune_partner_tasks \
+    --project 2026_04_15_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```
 
@@ -38,7 +38,7 @@ python -m rslp.main olmoearth_evals launch \
     --tasks '["sentinel1_vessels"]' \
     --prefix 20260415 \
     --image_name yawenzzzz/rslpomp20260415a \
-    --project 2026_04_12_v1.1_finetune_partner_tasks \
+    --project 2026_04_15_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```
 
@@ -50,6 +50,6 @@ python -m rslp.main olmoearth_evals launch \
     --tasks '["landsat_vessels"]' \
     --prefix 20260415 \
     --image_name yawenzzzz/rslpomp20260415a \
-    --project 2026_04_12_v1.1_finetune_partner_tasks \
+    --project 2026_04_15_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```

--- a/rslp/olmoearth_evals/20260415_evals.md
+++ b/rslp/olmoearth_evals/20260415_evals.md
@@ -1,6 +1,6 @@
-# 20260413 Evals
+# 20260415 Evals
 
-Image: `yawenzzzz/rslpomp20260413f`
+Image: `yawenzzzz/rslpomp20260415a`
 Checkpoint: `/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000`
 W&B project: `2026_04_12_v1.1_finetune_partner_tasks`
 
@@ -12,8 +12,8 @@ Note: all tasks use `use_legacy_timestamps: true` since the checkpoint was train
 python -m rslp.main olmoearth_evals launch \
     --models '["olmoearth"]' \
     --tasks '["forest_loss_driver", "ecosystem", "lfmc_ts", "mangrove_ts", "marine_infra_ts", "nandi_ts", "sentinel2_vessels", "sentinel2_vessel_length", "sentinel2_vessel_type", "solar_farm_ts", "wind_turbine_ts", "awf_ts"]' \
-    --prefix 20260413 \
-    --image_name yawenzzzz/rslpomp20260413f \
+    --prefix 20260415 \
+    --image_name yawenzzzz/rslpomp20260415a \
     --project 2026_04_12_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```
@@ -24,8 +24,8 @@ python -m rslp.main olmoearth_evals launch \
 python -m rslp.main olmoearth_evals launch \
     --models '["olmoearth"]' \
     --tasks '["awf_mm", "lfmc_mm", "mangrove_mm", "marine_infra_mm", "nandi_mm", "solar_farm_mm", "wind_turbine_mm"]' \
-    --prefix 20260413 \
-    --image_name yawenzzzz/rslpomp20260413f \
+    --prefix 20260415 \
+    --image_name yawenzzzz/rslpomp20260415a \
     --project 2026_04_12_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```
@@ -36,8 +36,8 @@ python -m rslp.main olmoearth_evals launch \
 python -m rslp.main olmoearth_evals launch \
     --models '["olmoearth"]' \
     --tasks '["sentinel1_vessels"]' \
-    --prefix 20260413 \
-    --image_name yawenzzzz/rslpomp20260413f \
+    --prefix 20260415 \
+    --image_name yawenzzzz/rslpomp20260415a \
     --project 2026_04_12_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```
@@ -48,8 +48,8 @@ python -m rslp.main olmoearth_evals launch \
 python -m rslp.main olmoearth_evals launch \
     --models '["olmoearth"]' \
     --tasks '["landsat_vessels"]' \
-    --prefix 20260413 \
-    --image_name yawenzzzz/rslpomp20260413f \
+    --prefix 20260415 \
+    --image_name yawenzzzz/rslpomp20260415a \
     --project 2026_04_12_v1.1_finetune_partner_tasks \
     --model_config '{"use_legacy_timestamps": "true", "checkpoint_path": "/weka/dfive-default/olmoearth_pretrain/checkpoints/yawenzzzz/single_bandset_no_s1_drop_random_time_dropout_0.2/step600000"}'
 ```

--- a/rslp/olmoearth_evals/launch.py
+++ b/rslp/olmoearth_evals/launch.py
@@ -1,6 +1,7 @@
 """Launch OlmoEarth fine-tuning evals."""
 
 import json
+import os
 import subprocess  # nosec
 
 from rslearn.utils.geometry import PixelBounds
@@ -147,8 +148,11 @@ def launch(
                 ]
 
             # Build extra_args for the training script.
+            # Expand RSLP_PREFIX here since rslearn's RslearnArgumentParser
+            # only substitutes env vars in config file content, not CLI args.
+            rslp_prefix = os.environ["RSLP_PREFIX"]
             all_extra_args: list[str] = [
-                "--management_dir=${RSLP_PREFIX}/projects",
+                f"--management_dir={rslp_prefix}/projects",
             ]
             if use_embeddings:
                 all_extra_args.append(


### PR DESCRIPTION
One more issue: `RSLP_PREFIX` is not expanded correctly in the `management_dir`, which cause the checkpoints not been saved properly, the task log says `2026-04-13T19:56:12.061Z 2026-04-13 19:56:12,059 - INFO - saved checkpoint to ${RSLP_PREFIX}/projects/2026_04_12_v1.1_finetune_partner_tasks/20260413_forest_loss_driver_olmoearth/last.ckpt` but no checkpoints been saved