### PR TITLE
LFMC subsampling for olmoearth_pretrain

### DIFF
--- a/data/helios/v2_lfmc/subsample/woody3k_lprobe.yaml
+++ b/data/helios/v2_lfmc/subsample/woody3k_lprobe.yaml
@@ -1,0 +1,109 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
+            init_args:
+              model_id: OLMOEARTH_V1_1_BASE
+              patch_size: 4
+        decoders:
+          lfmc_estimation:
+            - class_path: rslearn.models.upsample.Upsample
+              init_args:
+                scale_factor: 4
+            - class_path: rslearn.models.conv.Conv
+              init_args:
+                in_channels: 768
+                out_channels: 1
+                kernel_size: 1
+                activation:
+                  class_path: torch.nn.Identity
+            - class_path: rslearn.train.tasks.per_pixel_regression.PerPixelRegressionHead
+    lr: 0.00002
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 0
+        cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/lfmc/20251023/woody/scratch/dataset
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_item_groups: true
+        load_all_layers: true
+      targets:
+        data_type: "raster"
+        layers: ["labels"]
+        bands: ["value"]
+        dtype: FLOAT32
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          lfmc_estimation:
+            class_path: rslearn.train.tasks.per_pixel_regression.PerPixelRegressionTask
+            init_args:
+              nodata_value: -1
+              metrics: ["rmse", "r2"]
+              #scale_factor: 0.0024038
+              target_mean: 108.389520
+              target_std: 36.616698
+
+        input_mapping:
+          lfmc_estimation:
+            targets: "targets"
+    batch_size: 32
+    num_workers: 16
+    default_config:
+      crop_size: 32
+      transforms:
+        - class_path: rslearn.models.olmoearth_pretrain.norm.OlmoEarthNormalize
+          init_args:
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      groups: ["spatial_split"]
+      tags:
+        split: "train"
+        oep_eval_big: ""
+    val_config:
+      groups: ["spatial_split"]
+      tags:
+        split: "val"
+        oep_eval_big: ""
+    test_config:
+      groups: ["spatial_split"]
+      tags:
+        split: "test"
+        oep_eval_big: ""
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.checkpointing.ManagedBestLastCheckpoint
+      init_args:
+        monitor: val_loss
+        mode: min
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 50
+        unfreeze_lr_factor: 10
+management_dir: ${RSLP_PREFIX}/projects
+project_name: 20260528_lfmc_finetune
+run_name: placeholder

--- a/data/helios/v2_lfmc/subsample/woody3k_unet.yaml
+++ b/data/helios/v2_lfmc/subsample/woody3k_unet.yaml
@@ -1,0 +1,101 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.multitask.MultiTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
+            init_args:
+              model_id: OLMOEARTH_V1_1_BASE
+              patch_size: 4
+        decoders:
+          lfmc_estimation:
+            - class_path: rslearn.models.unet.UNetDecoder
+              init_args:
+                in_channels: [[4, 768]]
+                out_channels: 1
+                conv_layers_per_resolution: 2
+                num_channels: {8: 512, 4: 512, 2: 256, 1: 128}
+            - class_path: rslearn.train.tasks.per_pixel_regression.PerPixelRegressionHead
+    lr: 0.00002
+    scheduler:
+      class_path: rslearn.train.scheduler.PlateauScheduler
+      init_args:
+        factor: 0.2
+        patience: 2
+        min_lr: 0
+        cooldown: 10
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    path: /weka/dfive-default/rslearn-eai/datasets/lfmc/20251023/woody/scratch/dataset
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_item_groups: true
+        load_all_layers: true
+      targets:
+        data_type: "raster"
+        layers: ["labels"]
+        bands: ["value"]
+        dtype: FLOAT32
+        is_target: true
+    task:
+      class_path: rslearn.train.tasks.multi_task.MultiTask
+      init_args:
+        tasks:
+          lfmc_estimation:
+            class_path: rslearn.train.tasks.per_pixel_regression.PerPixelRegressionTask
+            init_args:
+              nodata_value: -1
+              metrics: ["rmse", "r2"]
+        input_mapping:
+          lfmc_estimation:
+            targets: "targets"
+    batch_size: 32
+    num_workers: 16
+    default_config:
+      crop_size: 32
+      transforms:
+        - class_path: rslearn.models.olmoearth_pretrain.norm.OlmoEarthNormalize
+          init_args:
+            band_names:
+              sentinel2_l2a: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+    train_config:
+      groups: ["spatial_split"]
+      tags:
+        split: "train"
+        oep_eval_big: ""
+    val_config:
+      groups: ["spatial_split"]
+      tags:
+        split: "val"
+        oep_eval_big: ""
+    test_config:
+      groups: ["spatial_split"]
+      tags:
+        split: "test"
+        oep_eval_big: ""
+trainer:
+  max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: "epoch"
+    - class_path: rslearn.train.callbacks.checkpointing.ManagedBestLastCheckpoint
+      init_args:
+        monitor: val_loss
+        mode: min
+    - class_path: rslearn.train.callbacks.freeze_unfreeze.FreezeUnfreeze
+      init_args:
+        module_selector: ["model", "encoder", 0]
+        unfreeze_at_epoch: 20
+        unfreeze_lr_factor: 10
+management_dir: ${RSLP_PREFIX}/projects
+project_name: 20260528_lfmc_finetune
+run_name: placeholder

--- a/rslp/lfmc/compute_target_stats.py
+++ b/rslp/lfmc/compute_target_stats.py
@@ -1,0 +1,285 @@
+"""Compute mean/std of LFMC target values over a split (and optional tag).
+
+These statistics are intended to be plugged into the ``target_mean`` / ``target_std``
+arguments of ``rslearn.train.tasks.per_pixel_regression.PerPixelRegressionTask`` so that
+the regression target is normalized during training while metrics are still reported in
+the original units.
+
+The statistics are computed only over *valid* pixels: pixels equal to the ignore value
+(``-1`` by default, matching the task's ``nodata_value``) and non-finite pixels are
+excluded. Windows are filtered the same way the training data module filters them: by
+group, by the ``split`` option, and (optionally) by requiring a tag option to be present.
+
+IMPORTANT: only compute these statistics on the train split to avoid leaking validation
+or test information into the normalization.
+
+Usage:
+    python -m rslp.lfmc.compute_target_stats \
+        --dataset_path /weka/dfive-default/rslearn-eai/datasets/lfmc/20251023/woody/scratch/dataset \
+        --split train \
+        --tag oep_eval_big
+"""
+
+import argparse
+import json
+import math
+import os
+from collections.abc import Iterable
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
+
+import numpy as np
+import rasterio
+
+
+@dataclass
+class PixelStats:
+    """Streaming accumulator for per-pixel statistics over valid pixels."""
+
+    count: int = 0
+    total: float = 0.0
+    total_sq: float = 0.0
+    minimum: float = math.inf
+    maximum: float = -math.inf
+
+    def merge(self, other: "PixelStats") -> None:
+        """Merge another accumulator into this one."""
+        self.count += other.count
+        self.total += other.total
+        self.total_sq += other.total_sq
+        self.minimum = min(self.minimum, other.minimum)
+        self.maximum = max(self.maximum, other.maximum)
+
+    @property
+    def mean(self) -> float:
+        """Mean over valid pixels."""
+        if self.count == 0:
+            raise ValueError("no valid pixels found")
+        return self.total / self.count
+
+    def std(self, ddof: int = 0) -> float:
+        """Standard deviation over valid pixels.
+
+        Args:
+            ddof: delta degrees of freedom. Use 0 (population std) for normalization.
+        """
+        if self.count - ddof <= 0:
+            raise ValueError("not enough valid pixels to compute std")
+        # Var = E[x^2] - E[x]^2, scaled to the requested ddof. Clamp tiny negatives that
+        # can arise from floating point error.
+        variance = (self.total_sq - self.total**2 / self.count) / (self.count - ddof)
+        return math.sqrt(max(variance, 0.0))
+
+
+def _matches_filters(
+    options: dict,
+    split: str | None,
+    tag: str | None,
+) -> bool:
+    """Return whether a window's options pass the split/tag filters.
+
+    Mirrors the tag filtering done by rslearn's ModelDataset: the tag key must be present
+    in the window options (an empty configured value just requires presence).
+    """
+    if split is not None and options.get("split") != split:
+        return False
+    if tag is not None and tag not in options:
+        return False
+    return True
+
+
+def _select_window_dirs(
+    dataset_path: str,
+    group: str,
+    split: str | None,
+    tag: str | None,
+) -> list[str]:
+    """Find window directories matching the split/tag filters."""
+    windows_dir = os.path.join(dataset_path, "windows", group)
+    names = sorted(os.listdir(windows_dir))
+    selected = []
+    for name in names:
+        window_dir = os.path.join(windows_dir, name)
+        meta_path = os.path.join(window_dir, "metadata.json")
+        if not os.path.isfile(meta_path):
+            continue
+        with open(meta_path) as f:
+            meta = json.load(f)
+        if _matches_filters(meta.get("options", {}), split, tag):
+            selected.append(window_dir)
+    return selected
+
+
+# Globals set per worker process so the geotiff path can be built without re-passing
+# constant arguments for every task.
+_LAYER = "labels"
+_IGNORE_VALUE = -1.0
+
+
+def _init_worker(layer: str, ignore_value: float) -> None:
+    global _LAYER, _IGNORE_VALUE
+    _LAYER = layer
+    _IGNORE_VALUE = ignore_value
+
+
+def _window_stats(window_dir: str) -> PixelStats:
+    """Read one window's label raster and accumulate stats over valid pixels."""
+    stats = PixelStats()
+    geotiff_path = os.path.join(window_dir, "layers", _LAYER, "value", "geotiff.tif")
+    if not os.path.isfile(geotiff_path):
+        return stats
+    with rasterio.open(geotiff_path) as ds:
+        array = ds.read().astype(np.float64)
+    valid = np.isfinite(array) & (array != _IGNORE_VALUE)
+    values = array[valid]
+    if values.size == 0:
+        return stats
+    stats.count = int(values.size)
+    stats.total = float(values.sum())
+    stats.total_sq = float(np.square(values).sum())
+    stats.minimum = float(values.min())
+    stats.maximum = float(values.max())
+    return stats
+
+
+def compute_stats(
+    window_dirs: Iterable[str],
+    layer: str,
+    ignore_value: float,
+    workers: int,
+) -> PixelStats:
+    """Compute aggregate pixel statistics across the given window directories."""
+    window_dirs = list(window_dirs)
+    total = PixelStats()
+    if workers <= 1:
+        _init_worker(layer, ignore_value)
+        for i, window_dir in enumerate(window_dirs):
+            total.merge(_window_stats(window_dir))
+            if (i + 1) % 5000 == 0:
+                print(f"  ... processed {i + 1}/{len(window_dirs)} windows")
+        return total
+
+    with ProcessPoolExecutor(
+        max_workers=workers,
+        initializer=_init_worker,
+        initargs=(layer, ignore_value),
+    ) as executor:
+        futures = {
+            executor.submit(_window_stats, window_dir): window_dir
+            for window_dir in window_dirs
+        }
+        for i, future in enumerate(as_completed(futures)):
+            total.merge(future.result())
+            if (i + 1) % 5000 == 0:
+                print(f"  ... processed {i + 1}/{len(window_dirs)} windows")
+    return total
+
+
+def main() -> None:
+    """Compute and report LFMC target mean/std for a split."""
+    parser = argparse.ArgumentParser(
+        description="Compute mean/std of LFMC target values over a split."
+    )
+    parser.add_argument("--dataset_path", type=str, required=True)
+    parser.add_argument(
+        "--group",
+        type=str,
+        default="spatial_split",
+        help="Window group to read (default: spatial_split).",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="train",
+        help="Only include windows whose 'split' option equals this. "
+        "Pass an empty string to disable the split filter.",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        default=None,
+        help="If set, only include windows that have this tag option (e.g. "
+        "oep_eval_big).",
+    )
+    parser.add_argument(
+        "--layer",
+        type=str,
+        default="labels",
+        help="Raster layer holding the target (default: labels).",
+    )
+    parser.add_argument(
+        "--ignore_value",
+        type=float,
+        default=-1.0,
+        help="Pixel value to treat as invalid/nodata (default: -1).",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=16,
+        help="Number of worker processes for reading rasters (default: 16).",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Optional path to write the computed stats as JSON.",
+    )
+    args = parser.parse_args()
+
+    split = args.split if args.split else None
+
+    print(
+        f"Selecting windows from group '{args.group}' "
+        f"(split={split}, tag={args.tag})..."
+    )
+    window_dirs = _select_window_dirs(args.dataset_path, args.group, split, args.tag)
+    print(f"  Selected {len(window_dirs)} windows")
+    if not window_dirs:
+        raise RuntimeError("no windows matched the given filters")
+
+    print("Reading target rasters and accumulating statistics...")
+    stats = compute_stats(window_dirs, args.layer, args.ignore_value, args.workers)
+
+    if stats.count == 0:
+        raise RuntimeError("no valid target pixels found")
+
+    mean = stats.mean
+    std_pop = stats.std(ddof=0)
+    std_sample = stats.std(ddof=1)
+
+    result = {
+        "dataset_path": args.dataset_path,
+        "group": args.group,
+        "split": split,
+        "tag": args.tag,
+        "layer": args.layer,
+        "ignore_value": args.ignore_value,
+        "num_windows": len(window_dirs),
+        "num_valid_pixels": stats.count,
+        "mean": mean,
+        "std": std_pop,
+        "std_sample": std_sample,
+        "min": stats.minimum,
+        "max": stats.maximum,
+    }
+
+    print("\n=== LFMC target statistics (valid pixels only) ===")
+    print(f"  windows:       {len(window_dirs)}")
+    print(f"  valid pixels:  {stats.count}")
+    print(f"  mean:          {mean:.6f}")
+    print(f"  std (pop):     {std_pop:.6f}")
+    print(f"  std (sample):  {std_sample:.6f}")
+    print(f"  min / max:     {stats.minimum:.6f} / {stats.maximum:.6f}")
+    print("\nUse these in the PerPixelRegressionTask config:")
+    print(f"  target_mean: {mean:.6f}")
+    print(f"  target_std: {std_pop:.6f}")
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"\nWrote stats to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rslp/lfmc/subsample_oep_eval.py
+++ b/rslp/lfmc/subsample_oep_eval.py
@@ -1,4 +1,4 @@
-"""Tag a spatially-balanced subset of LFMC windows with the oep_eval tag.
+"""Tag a spatially-balanced subset of LFMC windows with a configurable tag.
 
 For train: selects ~1000 windows distributed evenly across US states, operating
 at the location level. Each selected location contributes at most 1 year of
@@ -6,7 +6,7 @@ samples (the densest 365-day window), maximizing geographic coverage.
 For val/test: tags ALL windows.
 
 Usage:
-    python subsample_oep_eval.py --dataset_path /path/to/dataset --target_train 1000 --seed 42
+    python subsample_oep_eval.py --dataset_path /path/to/dataset --tag oep_eval --target_train 1000 --seed 42
 """
 
 import argparse
@@ -220,8 +220,8 @@ def select_locations_balanced(
     return selected
 
 
-def tag_windows(windows: list[dict]) -> int:
-    """Add oep_eval tag to the given windows' metadata.json files."""
+def tag_windows(windows: list[dict], tag: str) -> int:
+    """Add the given tag to the windows' metadata.json files."""
     tagged = 0
     for i, w in enumerate(windows):
         if i % 2000 == 0 and i > 0:
@@ -229,8 +229,8 @@ def tag_windows(windows: list[dict]) -> int:
         meta_path = os.path.join(w["_dir"], "metadata.json")
         with open(meta_path) as f:
             meta = json.load(f)
-        if "oep_eval" not in meta.get("options", {}):
-            meta.setdefault("options", {})["oep_eval"] = ""
+        if tag not in meta.get("options", {}):
+            meta.setdefault("options", {})[tag] = ""
             with open(meta_path, "w") as f:
                 json.dump(meta, f)
             tagged += 1
@@ -340,9 +340,10 @@ def subsample_split(
 
 
 def main() -> None:
-    """Tag a spatially-balanced oep_eval subset for LFMC datasets."""
-    parser = argparse.ArgumentParser(description="Tag oep_eval subset for LFMC")
+    """Tag a spatially-balanced subset for LFMC datasets."""
+    parser = argparse.ArgumentParser(description="Tag a subset for LFMC")
     parser.add_argument("--dataset_path", type=str, required=True)
+    parser.add_argument("--tag", type=str, default="oep_eval", help="Tag name to apply")
     parser.add_argument("--target_train", type=int, default=1000)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
@@ -423,16 +424,16 @@ def main() -> None:
         return
 
     # Tag windows
-    print("\nTagging selected train samples...")
-    train_tagged = tag_windows(selected_train)
+    print(f"\nTagging selected train samples with '{args.tag}'...")
+    train_tagged = tag_windows(selected_train, args.tag)
     print(f"  Tagged {train_tagged} train samples")
 
-    print("Tagging selected val samples...")
-    val_tagged = tag_windows(selected_val)
+    print(f"Tagging selected val samples with '{args.tag}'...")
+    val_tagged = tag_windows(selected_val, args.tag)
     print(f"  Tagged {val_tagged} val samples")
 
-    print("Tagging selected test samples...")
-    test_tagged = tag_windows(selected_test)
+    print(f"Tagging selected test samples with '{args.tag}'...")
+    test_tagged = tag_windows(selected_test, args.tag)
     print(f"  Tagged {test_tagged} test samples")
 
     # Write manifest
@@ -441,13 +442,14 @@ def main() -> None:
         "val": [w["_name"] for w in selected_val],
         "test": [w["_name"] for w in selected_test],
     }
-    manifest_path = os.path.join(args.dataset_path, "oep_eval_manifest.json")
+    manifest_path = os.path.join(args.dataset_path, f"{args.tag}_manifest.json")
     with open(manifest_path, "w") as f:
         json.dump(manifest, f, indent=2)
     print(f"\nWrote manifest to {manifest_path}")
 
     # Write stats
     stats = {
+        "tag": args.tag,
         "seed": args.seed,
         "one_year_cap_days": 365,
         "val_max_samples_threshold": VAL_MAX_SAMPLES,
@@ -462,7 +464,7 @@ def main() -> None:
         "val": val_stats,
         "test": test_stats,
     }
-    stats_path = os.path.join(args.dataset_path, "oep_eval_stats.json")
+    stats_path = os.path.join(args.dataset_path, f"{args.tag}_stats.json")
     with open(stats_path, "w") as f:
         json.dump(stats, f, indent=2)
     print(f"Wrote stats to {stats_path}")

--- a/rslp/lfmc/subsample_oep_eval.py
+++ b/rslp/lfmc/subsample_oep_eval.py
@@ -1,5 +1,9 @@
 """Tag a spatially-balanced subset of LFMC windows with the oep_eval tag.
 
+WARNING: This script is intended to be run exactly once per dataset. It will
+refuse to run if a manifest file (oep_eval_manifest.json) from a previous run
+is found.
+
 For train: selects ~1000 windows distributed evenly across US states, operating
 at the location level. Each selected location contributes at most 1 year of
 samples (the densest 365-day window), maximizing geographic coverage.
@@ -234,8 +238,6 @@ def tag_windows(windows: list[dict]) -> int:
             with open(meta_path, "w") as f:
                 json.dump(meta, f)
             tagged += 1
-        else:
-            tagged += 1
     return tagged
 
 
@@ -356,6 +358,14 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    manifest_path = os.path.join(args.dataset_path, "oep_eval_manifest.json")
+    if os.path.exists(manifest_path):
+        raise RuntimeError(
+            f"Manifest file already exists at {manifest_path}. "
+            "This script is intended to be run exactly once per dataset. "
+            "Remove the manifest file manually if you need to re-run."
+        )
+
     print(f"Loading windows from {args.dataset_path}...")
     all_windows = load_windows(args.dataset_path)
     print(f"  Total windows: {len(all_windows)}")
@@ -441,7 +451,6 @@ def main() -> None:
         "val": [w["_name"] for w in selected_val],
         "test": [w["_name"] for w in selected_test],
     }
-    manifest_path = os.path.join(args.dataset_path, "oep_eval_manifest.json")
     with open(manifest_path, "w") as f:
         json.dump(manifest, f, indent=2)
     print(f"\nWrote manifest to {manifest_path}")

--- a/rslp/lfmc/subsample_oep_eval.py
+++ b/rslp/lfmc/subsample_oep_eval.py
@@ -1,0 +1,474 @@
+"""Tag a spatially-balanced subset of LFMC windows with the oep_eval tag.
+
+For train: selects ~1000 windows distributed evenly across US states, operating
+at the location level. Each selected location contributes at most 1 year of
+samples (the densest 365-day window), maximizing geographic coverage.
+For val/test: tags ALL windows.
+
+Usage:
+    python subsample_oep_eval.py --dataset_path /path/to/dataset --target_train 1000 --seed 42
+"""
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Any
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from pyproj import Transformer
+from shapely.geometry import Point
+
+LocKey = tuple[str, tuple[Any, ...]]
+
+US_STATES_SHP = (
+    "/weka/dfive-default/hadriens/datasets/Misc/Us states/cb_2018_us_state_20m.shp"
+)
+
+
+def load_windows(dataset_path: str) -> list[dict]:
+    """Load all window metadata from the dataset."""
+    windows_dir = os.path.join(dataset_path, "windows", "spatial_split")
+    names = os.listdir(windows_dir)
+    print(f"  Found {len(names)} window directories, loading metadata...")
+    windows = []
+    for i, name in enumerate(names):
+        if i % 5000 == 0 and i > 0:
+            print(f"    ... loaded {i}/{len(names)}")
+        meta_path = os.path.join(windows_dir, name, "metadata.json")
+        if not os.path.isfile(meta_path):
+            continue
+        with open(meta_path) as f:
+            meta = json.load(f)
+        meta["_dir"] = os.path.join(windows_dir, name)
+        meta["_name"] = name
+        windows.append(meta)
+    return windows
+
+
+def compute_location_centroid_wgs84(
+    crs: str, bounds: list, x_resolution: float, y_resolution: float
+) -> tuple[float, float]:
+    """Convert the center of pixel bounds to WGS84 lon/lat.
+
+    Bounds are stored in pixel coordinates; multiply by resolution to get
+    real-world UTM coordinates.
+    """
+    cx_pixel = (bounds[0] + bounds[2]) / 2.0
+    cy_pixel = (bounds[1] + bounds[3]) / 2.0
+    cx_utm = cx_pixel * x_resolution
+    cy_utm = cy_pixel * y_resolution
+    transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+    lon, lat = transformer.transform(cx_utm, cy_utm)
+    return lon, lat
+
+
+def get_window_date(window: dict) -> datetime:
+    """Extract the sample date from a window's time_range."""
+    return datetime.fromisoformat(window["time_range"][0])
+
+
+def best_one_year_subset(windows: list[dict]) -> list[dict]:
+    """Find the densest 365-day sliding window and return only those samples.
+
+    Slides across all sample dates and picks the 365-day interval containing
+    the most samples.
+    """
+    if len(windows) <= 1:
+        return windows
+
+    sorted_windows = sorted(windows, key=get_window_date)
+    dates = [get_window_date(w) for w in sorted_windows]
+    year_delta = timedelta(days=365)
+
+    best_start = 0
+    best_end = 0
+    best_count = 0
+
+    for i, start_date in enumerate(dates):
+        end_date = start_date + year_delta
+        # Find how many samples fall within [start_date, start_date + 365 days]
+        j = i
+        while j < len(dates) and dates[j] <= end_date:
+            j += 1
+        count = j - i
+        if count > best_count:
+            best_count = count
+            best_start = i
+            best_end = j
+
+    return sorted_windows[best_start:best_end]
+
+
+def assign_locations_to_states(
+    locations: dict[LocKey, list[dict]], states_gdf: gpd.GeoDataFrame
+) -> dict[LocKey, str]:
+    """Assign each location key to a US state via point-in-polygon."""
+    loc_keys = list(locations.keys())
+    points = []
+    for key in loc_keys:
+        crs, bounds = key[0], list(key[1])
+        first_window = locations[key][0]
+        x_res = first_window["projection"]["x_resolution"]
+        y_res = first_window["projection"]["y_resolution"]
+        lon, lat = compute_location_centroid_wgs84(crs, bounds, x_res, y_res)
+        points.append(Point(lon, lat))
+
+    points_gdf = gpd.GeoDataFrame(
+        {"loc_key": loc_keys}, geometry=points, crs="EPSG:4326"
+    )
+    states_gdf_4326 = states_gdf.to_crs("EPSG:4326")
+    joined = gpd.sjoin(points_gdf, states_gdf_4326[["NAME", "geometry"]], how="left")
+
+    loc_to_state: dict[LocKey, str] = {}
+    for _, row in joined.iterrows():
+        state = row.get("NAME")
+        if isinstance(state, str) and not pd.isna(state):
+            loc_to_state[row["loc_key"]] = state
+        else:
+            loc_to_state[row["loc_key"]] = "Unknown"
+    return loc_to_state
+
+
+def select_locations_balanced(
+    locations: dict[LocKey, list[dict]],
+    loc_to_state: dict[LocKey, str],
+    loc_one_year_count: dict[LocKey, int],
+    target: int,
+    seed: int,
+) -> list[LocKey]:
+    """Select locations with even distribution across states.
+
+    Uses the 1-year capped sample count for each location when computing quotas,
+    so that more locations can be selected for better geographic coverage.
+    Returns list of selected location keys.
+    """
+    rng = np.random.default_rng(seed)
+
+    state_to_locs: dict[str, list[LocKey]] = defaultdict(list)
+    for loc_key, state in loc_to_state.items():
+        state_to_locs[state].append(loc_key)
+
+    states_with_data = [s for s in state_to_locs if s != "Unknown"]
+    if not states_with_data:
+        states_with_data = list(state_to_locs.keys())
+
+    selected: list[LocKey] = []
+    remaining_target = target
+
+    # Iteratively allocate: states with fewer capped samples than quota get all
+    settled_states = set()
+    for _ in range(20):
+        unsettled = [s for s in states_with_data if s not in settled_states]
+        if not unsettled:
+            break
+
+        per_state_quota = remaining_target / len(unsettled) if unsettled else 0
+        newly_settled = []
+
+        for state in unsettled:
+            locs = state_to_locs[state]
+            total_capped = sum(loc_one_year_count[lk] for lk in locs)
+            if total_capped <= per_state_quota:
+                selected.extend(locs)
+                remaining_target -= total_capped
+                newly_settled.append(state)
+
+        if not newly_settled:
+            break
+        settled_states.update(newly_settled)
+
+    # For remaining states, select locations to fill quota
+    unsettled = [s for s in states_with_data if s not in settled_states]
+    if unsettled:
+        per_state_quota = remaining_target / len(unsettled) if unsettled else 0
+        for state in unsettled:
+            locs = state_to_locs[state]
+            locs_with_count = [(lk, loc_one_year_count[lk]) for lk in locs]
+
+            # Shuffle for randomness, then sort by count (prefer dense locations)
+            shuffled = list(locs_with_count)
+            rng.shuffle(shuffled)
+            shuffled.sort(key=lambda x: x[1], reverse=True)
+
+            state_selected: list[LocKey] = []
+            state_total = 0
+            for lk, count in shuffled:
+                if state_total + count > per_state_quota and state_selected:
+                    break
+                state_selected.append(lk)
+                state_total += count
+
+            selected.extend(state_selected)
+            remaining_target -= state_total
+
+    # Include "Unknown" state locations if any remain and we're under target
+    if "Unknown" in state_to_locs and remaining_target > 0:
+        unknown_locs = state_to_locs["Unknown"]
+        unknown_with_count = [(lk, loc_one_year_count[lk]) for lk in unknown_locs]
+        rng.shuffle(unknown_with_count)
+        unknown_with_count.sort(key=lambda x: x[1], reverse=True)
+        for lk, count in unknown_with_count:
+            if remaining_target <= 0:
+                break
+            selected.append(lk)
+            remaining_target -= count
+
+    return selected
+
+
+def tag_windows(windows: list[dict]) -> int:
+    """Add oep_eval tag to the given windows' metadata.json files."""
+    tagged = 0
+    for i, w in enumerate(windows):
+        if i % 2000 == 0 and i > 0:
+            print(f"    ... tagged {i}/{len(windows)}")
+        meta_path = os.path.join(w["_dir"], "metadata.json")
+        with open(meta_path) as f:
+            meta = json.load(f)
+        if "oep_eval" not in meta.get("options", {}):
+            meta.setdefault("options", {})["oep_eval"] = ""
+            with open(meta_path, "w") as f:
+                json.dump(meta, f)
+            tagged += 1
+        else:
+            tagged += 1
+    return tagged
+
+
+VAL_MAX_SAMPLES = 800
+TEST_MAX_SAMPLES = 500
+
+
+def subsample_split(
+    windows: list[dict],
+    target: int,
+    states_gdf: gpd.GeoDataFrame,
+    seed: int,
+    split_name: str,
+) -> tuple[list[dict], dict]:
+    """Subsample a split using spatially-balanced selection with 1-year cap.
+
+    Returns (selected_windows, split_stats_dict).
+    """
+    # Group by location
+    locations: dict[LocKey, list[dict]] = defaultdict(list)
+    for w in windows:
+        key: LocKey = (w["projection"]["crs"], tuple(w["bounds"]))
+        locations[key].append(w)
+    print(f"  Unique {split_name} locations: {len(locations)}")
+
+    # Precompute best 1-year subset for each location
+    print(f"  Computing best 1-year window per {split_name} location...")
+    loc_one_year: dict[LocKey, list[dict]] = {}
+    loc_one_year_count: dict[LocKey, int] = {}
+    for loc_key, loc_windows in locations.items():
+        subset = best_one_year_subset(loc_windows)
+        loc_one_year[loc_key] = subset
+        loc_one_year_count[loc_key] = len(subset)
+    avg_capped = np.mean(list(loc_one_year_count.values()))
+    print(f"  Avg samples per location (1-year cap): {avg_capped:.1f}")
+
+    # Assign locations to states
+    print(f"  Assigning {split_name} locations to states...")
+    loc_to_state = assign_locations_to_states(locations, states_gdf)
+
+    # State distribution
+    state_total_samples: dict[str, int] = defaultdict(int)
+    state_total_locations: dict[str, int] = defaultdict(int)
+    for loc_key, state in loc_to_state.items():
+        state_total_samples[state] += len(locations[loc_key])
+        state_total_locations[state] += 1
+
+    # Select locations
+    print(f"  Selecting locations for ~{target} {split_name} samples...")
+    selected_locs = select_locations_balanced(
+        locations, loc_to_state, loc_one_year_count, target, seed
+    )
+
+    # Collect the 1-year subset
+    selected_windows = []
+    for loc_key in selected_locs:
+        selected_windows.extend(loc_one_year[loc_key])
+    print(
+        f"  Selected {len(selected_locs)} locations -> {len(selected_windows)} {split_name} samples"
+    )
+
+    # Per-state reporting
+    selected_state_samples: dict[str, int] = defaultdict(int)
+    selected_state_locations: dict[str, int] = defaultdict(int)
+    for loc_key in selected_locs:
+        state = loc_to_state[loc_key]
+        selected_state_samples[state] += loc_one_year_count[loc_key]
+        selected_state_locations[state] += 1
+    print(f"\n  Per-state {split_name} selection:")
+    for state in sorted(selected_state_samples.keys()):
+        total_locs = state_total_locations[state]
+        sel_locs = selected_state_locations[state]
+        total_samp = state_total_samples[state]
+        sel_samp = selected_state_samples[state]
+        print(
+            f"    {state}: {sel_locs}/{total_locs} locations, {sel_samp}/{total_samp} samples"
+        )
+
+    # Build stats for this split
+    all_states = sorted(
+        set(list(selected_state_samples.keys()) + list(state_total_locations.keys()))
+    )
+    split_stats = {
+        "target_samples": target,
+        "total_locations": len(locations),
+        "selected_locations": len(selected_locs),
+        "total_samples": len(windows),
+        "selected_samples": len(selected_windows),
+        "avg_samples_per_location_1yr_cap": float(avg_capped),
+        "per_state": {
+            state: {
+                "total_locations": state_total_locations[state],
+                "selected_locations": selected_state_locations.get(state, 0),
+                "total_samples": state_total_samples[state],
+                "selected_samples": selected_state_samples.get(state, 0),
+            }
+            for state in all_states
+        },
+    }
+
+    return selected_windows, split_stats
+
+
+def main() -> None:
+    """Tag a spatially-balanced oep_eval subset for LFMC datasets."""
+    parser = argparse.ArgumentParser(description="Tag oep_eval subset for LFMC")
+    parser.add_argument("--dataset_path", type=str, required=True)
+    parser.add_argument("--target_train", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--states_shp",
+        type=str,
+        default=US_STATES_SHP,
+        help="Path to US states shapefile",
+    )
+    parser.add_argument(
+        "--dry_run", action="store_true", help="Print stats without tagging"
+    )
+    args = parser.parse_args()
+
+    print(f"Loading windows from {args.dataset_path}...")
+    all_windows = load_windows(args.dataset_path)
+    print(f"  Total windows: {len(all_windows)}")
+
+    # Split by train/val/test
+    train_windows = [
+        w for w in all_windows if w.get("options", {}).get("split") == "train"
+    ]
+    val_windows = [w for w in all_windows if w.get("options", {}).get("split") == "val"]
+    test_windows = [
+        w for w in all_windows if w.get("options", {}).get("split") == "test"
+    ]
+    print(
+        f"  Train: {len(train_windows)}, Val: {len(val_windows)}, Test: {len(test_windows)}"
+    )
+
+    # Load states shapefile
+    print("Loading US states shapefile...")
+    states_gdf = gpd.read_file(args.states_shp)
+
+    # --- Train subsampling ---
+    print(f"\n--- TRAIN (target: {args.target_train}) ---")
+    selected_train, train_stats = subsample_split(
+        train_windows, args.target_train, states_gdf, args.seed, "train"
+    )
+
+    # --- Val: subsample if over threshold, else use all ---
+    if len(val_windows) > VAL_MAX_SAMPLES:
+        print(
+            f"\n--- VAL (target: {VAL_MAX_SAMPLES}, total {len(val_windows)} > {VAL_MAX_SAMPLES}) ---"
+        )
+        selected_val, val_stats = subsample_split(
+            val_windows, VAL_MAX_SAMPLES, states_gdf, args.seed + 1, "val"
+        )
+    else:
+        print(
+            f"\n--- VAL: using all {len(val_windows)} samples (below {VAL_MAX_SAMPLES} threshold) ---"
+        )
+        selected_val = val_windows
+        val_stats = {
+            "total_samples": len(val_windows),
+            "selected_samples": len(val_windows),
+        }
+
+    # --- Test: subsample if over threshold, else use all ---
+    if len(test_windows) > TEST_MAX_SAMPLES:
+        print(
+            f"\n--- TEST (target: {TEST_MAX_SAMPLES}, total {len(test_windows)} > {TEST_MAX_SAMPLES}) ---"
+        )
+        selected_test, test_stats = subsample_split(
+            test_windows, TEST_MAX_SAMPLES, states_gdf, args.seed + 2, "test"
+        )
+    else:
+        print(
+            f"\n--- TEST: using all {len(test_windows)} samples (below {TEST_MAX_SAMPLES} threshold) ---"
+        )
+        selected_test = test_windows
+        test_stats = {
+            "total_samples": len(test_windows),
+            "selected_samples": len(test_windows),
+        }
+
+    if args.dry_run:
+        print("\n[DRY RUN] No tagging performed.")
+        return
+
+    # Tag windows
+    print("\nTagging selected train samples...")
+    train_tagged = tag_windows(selected_train)
+    print(f"  Tagged {train_tagged} train samples")
+
+    print("Tagging selected val samples...")
+    val_tagged = tag_windows(selected_val)
+    print(f"  Tagged {val_tagged} val samples")
+
+    print("Tagging selected test samples...")
+    test_tagged = tag_windows(selected_test)
+    print(f"  Tagged {test_tagged} test samples")
+
+    # Write manifest
+    manifest = {
+        "train": [w["_name"] for w in selected_train],
+        "val": [w["_name"] for w in selected_val],
+        "test": [w["_name"] for w in selected_test],
+    }
+    manifest_path = os.path.join(args.dataset_path, "oep_eval_manifest.json")
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+    print(f"\nWrote manifest to {manifest_path}")
+
+    # Write stats
+    stats = {
+        "seed": args.seed,
+        "one_year_cap_days": 365,
+        "val_max_samples_threshold": VAL_MAX_SAMPLES,
+        "test_max_samples_threshold": TEST_MAX_SAMPLES,
+        "total_samples": len(all_windows),
+        "tagged_samples": {
+            "train": len(selected_train),
+            "val": len(selected_val),
+            "test": len(selected_test),
+        },
+        "train": train_stats,
+        "val": val_stats,
+        "test": test_stats,
+    }
+    stats_path = os.path.join(args.dataset_path, "oep_eval_stats.json")
+    with open(stats_path, "w") as f:
+        json.dump(stats, f, indent=2)
+    print(f"Wrote stats to {stats_path}")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/rslp/lfmc/visualize_oep_eval.py
+++ b/rslp/lfmc/visualize_oep_eval.py
@@ -1,16 +1,17 @@
-"""Visualize oep_eval subsampled locations vs all original locations on a US map.
+"""Visualize tagged subsampled locations vs all original locations on a US map.
 
 Produces a 2x2 figure:
   - Row 1: Woody dataset
   - Row 2: Herbaceous dataset
   - Left column: all original locations
-  - Right column: oep_eval-tagged subset only
+  - Right column: tagged subset only
 Points are colored by split (train=blue, val=orange, test=green).
 
 Usage:
     python visualize_oep_eval.py \
         --woody_path /path/to/woody/dataset \
         --herbaceous_path /path/to/herbaceous/dataset \
+        --tag oep_eval \
         --output oep_eval_map.png
 """
 
@@ -63,8 +64,10 @@ def load_locations(dataset_path: str) -> dict[str, list[tuple[float, float]]]:
     return dict(locations)
 
 
-def load_tagged_locations(dataset_path: str) -> dict[str, list[tuple[float, float]]]:
-    """Load unique locations that have the oep_eval tag, per split."""
+def load_tagged_locations(
+    dataset_path: str, tag: str
+) -> dict[str, list[tuple[float, float]]]:
+    """Load unique locations that have the given tag, per split."""
     windows_dir = os.path.join(dataset_path, "windows", "spatial_split")
     seen: dict[str, set[tuple]] = defaultdict(set)
     locations: dict[str, list[tuple[float, float]]] = defaultdict(list)
@@ -76,7 +79,7 @@ def load_tagged_locations(dataset_path: str) -> dict[str, list[tuple[float, floa
         with open(meta_path) as f:
             meta = json.load(f)
 
-        if "oep_eval" not in meta.get("options", {}):
+        if tag not in meta.get("options", {}):
             continue
 
         split = meta.get("options", {}).get("split", "unknown")
@@ -135,10 +138,13 @@ def plot_locations_on_ax(
 
 
 def main() -> None:
-    """Visualize oep_eval subsampled vs original locations on a US map."""
-    parser = argparse.ArgumentParser(description="Visualize oep_eval locations")
+    """Visualize tagged subsampled vs original locations on a US map."""
+    parser = argparse.ArgumentParser(description="Visualize tagged locations")
     parser.add_argument("--woody_path", type=str, required=True)
     parser.add_argument("--herbaceous_path", type=str, required=True)
+    parser.add_argument(
+        "--tag", type=str, default="oep_eval", help="Tag name to filter on"
+    )
     parser.add_argument("--states_shp", type=str, default=US_STATES_SHP)
     parser.add_argument("--output", type=str, default="oep_eval_map.png")
     args = parser.parse_args()
@@ -150,21 +156,21 @@ def main() -> None:
 
     print("Loading woody locations...")
     woody_all = load_locations(args.woody_path)
-    woody_tagged = load_tagged_locations(args.woody_path)
+    woody_tagged = load_tagged_locations(args.woody_path, args.tag)
 
     print("Loading herbaceous locations...")
     herb_all = load_locations(args.herbaceous_path)
-    herb_tagged = load_tagged_locations(args.herbaceous_path)
+    herb_tagged = load_tagged_locations(args.herbaceous_path, args.tag)
 
     fig, axes = plt.subplots(2, 2, figsize=(16, 10))
 
     plot_locations_on_ax(axes[0, 0], woody_all, states_gdf, "Woody — All Locations")
     plot_locations_on_ax(
-        axes[0, 1], woody_tagged, states_gdf, "Woody — oep_eval Subset"
+        axes[0, 1], woody_tagged, states_gdf, f"Woody — {args.tag} Subset"
     )
     plot_locations_on_ax(axes[1, 0], herb_all, states_gdf, "Herbaceous — All Locations")
     plot_locations_on_ax(
-        axes[1, 1], herb_tagged, states_gdf, "Herbaceous — oep_eval Subset"
+        axes[1, 1], herb_tagged, states_gdf, f"Herbaceous — {args.tag} Subset"
     )
 
     plt.tight_layout()

--- a/rslp/lfmc/visualize_oep_eval.py
+++ b/rslp/lfmc/visualize_oep_eval.py
@@ -1,0 +1,176 @@
+"""Visualize oep_eval subsampled locations vs all original locations on a US map.
+
+Produces a 2x2 figure:
+  - Row 1: Woody dataset
+  - Row 2: Herbaceous dataset
+  - Left column: all original locations
+  - Right column: oep_eval-tagged subset only
+Points are colored by split (train=blue, val=orange, test=green).
+
+Usage:
+    python visualize_oep_eval.py \
+        --woody_path /path/to/woody/dataset \
+        --herbaceous_path /path/to/herbaceous/dataset \
+        --output oep_eval_map.png
+"""
+
+import argparse
+import json
+import os
+from collections import defaultdict
+
+import geopandas as gpd
+import matplotlib.pyplot as plt
+from pyproj import Transformer
+
+US_STATES_SHP = (
+    "/weka/dfive-default/hadriens/datasets/Misc/Us states/cb_2018_us_state_20m.shp"
+)
+
+SPLIT_COLORS = {"train": "#2176AE", "val": "#F77F00", "test": "#06D6A0"}
+
+
+def load_locations(dataset_path: str) -> dict[str, list[tuple[float, float]]]:
+    """Load unique locations per split, return {split: [(lon, lat), ...]}."""
+    windows_dir = os.path.join(dataset_path, "windows", "spatial_split")
+    seen: dict[str, set[tuple]] = defaultdict(set)
+    locations: dict[str, list[tuple[float, float]]] = defaultdict(list)
+
+    for name in os.listdir(windows_dir):
+        meta_path = os.path.join(windows_dir, name, "metadata.json")
+        if not os.path.isfile(meta_path):
+            continue
+        with open(meta_path) as f:
+            meta = json.load(f)
+
+        split = meta.get("options", {}).get("split", "unknown")
+        crs = meta["projection"]["crs"]
+        bounds = meta["bounds"]
+        loc_key = (crs, tuple(bounds))
+
+        if loc_key in seen[split]:
+            continue
+        seen[split].add(loc_key)
+
+        x_res = meta["projection"]["x_resolution"]
+        y_res = meta["projection"]["y_resolution"]
+        cx = (bounds[0] + bounds[2]) / 2.0 * x_res
+        cy = (bounds[1] + bounds[3]) / 2.0 * y_res
+        transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+        lon, lat = transformer.transform(cx, cy)
+        locations[split].append((lon, lat))
+
+    return dict(locations)
+
+
+def load_tagged_locations(dataset_path: str) -> dict[str, list[tuple[float, float]]]:
+    """Load unique locations that have the oep_eval tag, per split."""
+    windows_dir = os.path.join(dataset_path, "windows", "spatial_split")
+    seen: dict[str, set[tuple]] = defaultdict(set)
+    locations: dict[str, list[tuple[float, float]]] = defaultdict(list)
+
+    for name in os.listdir(windows_dir):
+        meta_path = os.path.join(windows_dir, name, "metadata.json")
+        if not os.path.isfile(meta_path):
+            continue
+        with open(meta_path) as f:
+            meta = json.load(f)
+
+        if "oep_eval" not in meta.get("options", {}):
+            continue
+
+        split = meta.get("options", {}).get("split", "unknown")
+        crs = meta["projection"]["crs"]
+        bounds = meta["bounds"]
+        loc_key = (crs, tuple(bounds))
+
+        if loc_key in seen[split]:
+            continue
+        seen[split].add(loc_key)
+
+        x_res = meta["projection"]["x_resolution"]
+        y_res = meta["projection"]["y_resolution"]
+        cx = (bounds[0] + bounds[2]) / 2.0 * x_res
+        cy = (bounds[1] + bounds[3]) / 2.0 * y_res
+        transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+        lon, lat = transformer.transform(cx, cy)
+        locations[split].append((lon, lat))
+
+    return dict(locations)
+
+
+def plot_locations_on_ax(
+    ax: plt.Axes,
+    locations: dict[str, list[tuple[float, float]]],
+    states_gdf: gpd.GeoDataFrame,
+    title: str,
+) -> None:
+    """Plot location points on a US map axis."""
+    states_gdf.boundary.plot(ax=ax, linewidth=0.5, color="gray")
+
+    for split in ["test", "val", "train"]:
+        if split not in locations:
+            continue
+        pts = locations[split]
+        if not pts:
+            continue
+        lons, lats = zip(*pts)
+        ax.scatter(
+            lons,
+            lats,
+            c=SPLIT_COLORS[split],
+            s=15,
+            alpha=0.7,
+            edgecolors="none",
+            label=f"{split} ({len(pts)} locs)",
+            zorder=3,
+        )
+
+    ax.set_xlim(-130, -65)
+    ax.set_ylim(24, 50)
+    ax.set_title(title, fontsize=11, fontweight="bold")
+    ax.set_aspect("equal")
+    ax.tick_params(labelsize=7)
+    ax.legend(loc="lower left", fontsize=7, framealpha=0.8)
+
+
+def main() -> None:
+    """Visualize oep_eval subsampled vs original locations on a US map."""
+    parser = argparse.ArgumentParser(description="Visualize oep_eval locations")
+    parser.add_argument("--woody_path", type=str, required=True)
+    parser.add_argument("--herbaceous_path", type=str, required=True)
+    parser.add_argument("--states_shp", type=str, default=US_STATES_SHP)
+    parser.add_argument("--output", type=str, default="oep_eval_map.png")
+    args = parser.parse_args()
+
+    print("Loading US states shapefile...")
+    states_gdf = gpd.read_file(args.states_shp)
+    states_gdf = states_gdf[~states_gdf["NAME"].isin(["Alaska", "Hawaii"])]
+    states_gdf = states_gdf.to_crs("EPSG:4326")
+
+    print("Loading woody locations...")
+    woody_all = load_locations(args.woody_path)
+    woody_tagged = load_tagged_locations(args.woody_path)
+
+    print("Loading herbaceous locations...")
+    herb_all = load_locations(args.herbaceous_path)
+    herb_tagged = load_tagged_locations(args.herbaceous_path)
+
+    fig, axes = plt.subplots(2, 2, figsize=(16, 10))
+
+    plot_locations_on_ax(axes[0, 0], woody_all, states_gdf, "Woody — All Locations")
+    plot_locations_on_ax(
+        axes[0, 1], woody_tagged, states_gdf, "Woody — oep_eval Subset"
+    )
+    plot_locations_on_ax(axes[1, 0], herb_all, states_gdf, "Herbaceous — All Locations")
+    plot_locations_on_ax(
+        axes[1, 1], herb_tagged, states_gdf, "Herbaceous — oep_eval Subset"
+    )
+
+    plt.tight_layout()
+    plt.savefig(args.output, dpi=150, bbox_inches="tight")
+    print(f"Saved figure to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds scripts to create a spatially-balanced oep_eval subset of the LFMC woody and herbaceous datasets. The subsampling script (subsample_oep_eval.py) selects ~1000 train samples distributed evenly across US states, operating at the location level with a 1-year temporal cap per location to maximize geographic diversity. Val and test splits are also subsampled if they exceed 800 and 500 samples respectively (relevant for woody), otherwise all samples are included. Each selected window is tagged with "oep_eval": "" in its metadata options, following the same pattern used in the wildfire/canada_nbac dataset. A companion visualization script (visualize_oep_eval.py) produces a 2x2 map showing all original locations vs. the tagged subset for both datasets.


<img width="947" height="504" alt="image" src="https://github.com/user-attachments/assets/5de13cd7-8b25-455f-8787-f047d07e464b" />
