### PR TITLE
sentinel1: use MapAllCropsDataset for memory-safe prediction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime@sha256:7db0e1bf4b1ac274ea09cf6358ab516f8a5c7d3d0e02311bed445f7e236a5d80
 
 RUN apt update
-RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget
+RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget build-essential
 
 # Install Go (used for Satlas smooth_point_labels_viterbi.go).
 RUN wget https://go.dev/dl/go1.22.12.linux-amd64.tar.gz

--- a/data/sentinel1_vessels/config.yaml
+++ b/data/sentinel1_vessels/config.yaml
@@ -40,6 +40,10 @@ model:
 data:
   class_path: rslearn.train.data_module.RslearnDataModule
   init_args:
+    # Read each all-crops prediction crop from disk on demand rather than loading
+    # the whole window into memory, so prediction memory stays bounded on large
+    # scenes (one window can span an entire Sentinel-1 scene).
+    use_map_all_crops_dataset: true
     path: /weka/dfive-default/rslearn-eai/datasets/sentinel1_vessels/dataset_v1/20250521/
     inputs:
       image_0:


### PR DESCRIPTION
Enable `use_map_all_crops_dataset` for the Sentinel-1 vessel pipeline so all-crops prediction reads each crop from disk on demand instead of loading the entire window. This keeps prediction memory bounded on large scenes (a Sentinel-1 window spans the whole scene), where the default `IterableAllCropsDataset` OOM-kills the worker.

One-line config flag; no code change here.

**Verified:** predict-stage memory ~29GB (OOM) → ~3GB, same 17 detections end-to-end on the failing scene.

**Depends on** allenai/rslearn#662 (adds `MapAllCropsDataset` + the flag) — must merge first, since the image builds rslearn from master.

**Supersedes** #315 (the `LazyAllCropsDataModule` workaround in this repo) — same result, but the capability lives in rslearn instead. #315 can be closed if this approach is preferred.