### PR TITLE
Ryan/sentinel1 fix crop fnames

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime@sha256:7db0e1bf4b1ac274ea09cf6358ab516f8a5c7d3d0e02311bed445f7e236a5d80
 
 RUN apt update
-RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget
+RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget build-essential
 
 # Install Go (used for Satlas smooth_point_labels_viterbi.go).
 RUN wget https://go.dev/dl/go1.22.12.linux-amd64.tar.gz

--- a/rslp/sentinel1_vessels/predict_pipeline.py
+++ b/rslp/sentinel1_vessels/predict_pipeline.py
@@ -691,5 +691,7 @@ def _build_predictions_and_crops(
                 with crop_fnames[band_name].open("wb") as f:
                     Image.fromarray(band_image).save(f, format="PNG")
 
+            detection.crop_fnames = crop_fnames
+
         detections_by_task[task_idx].append(detection)
     return detections_by_task


### PR DESCRIPTION
Frames were being orphaned in the Sentinel1 pipeline, causing no images to render.

Added `detection.crop_fnames = crop_fnames` after the per-band loop, so the written file paths are actually stored on the detection object