### PR TITLE
Dockerfile: add build-essential to fix packages requiring C compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime@sha256:7db0e1bf4b1ac274ea09cf6358ab516f8a5c7d3d0e02311bed445f7e236a5d80
 
 RUN apt update
-RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget
+RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget build-essential
 
 # Install Go (used for Satlas smooth_point_labels_viterbi.go).
 RUN wget https://go.dev/dl/go1.22.12.linux-amd64.tar.gz


### PR DESCRIPTION
## Summary
- Adds `build-essential` to the apt install step so packages like `stringzilla` that require a C compiler can build successfully

## Background
The base image (`pytorch/pytorch`) is a minimal runtime image — it only includes what's needed to run PyTorch, not to compile C code. When `stringzilla` v4.6.2 was published without pre-built wheels for the Linux/amd64 + Python 3.11 combination used in the image, pip tried to compile it from source and failed because `gcc` wasn't present. Adding `build-essential` puts `gcc` in the image so source compilation works. This slightly increases image size (~200MB) but has no runtime effect.

## Test plan
- [ ] CI Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)