### PR TITLE
sentinel1: use INTERSECTS for historical layer in image-file predict config

### DIFF
--- a/data/sentinel1_vessels/config_predict_local_files.json
+++ b/data/sentinel1_vessels/config_predict_local_files.json
@@ -62,7 +62,8 @@
           "src_dir": "PLACEHOLDER"
         },
         "query_config": {
-          "max_matches": 2
+          "max_matches": 2,
+          "space_mode": "INTERSECTS"
         }
       },
       "resampling_method": "cubic",

--- a/rslp/sentinel1_vessels/predict_pipeline.py
+++ b/rslp/sentinel1_vessels/predict_pipeline.py
@@ -50,6 +50,9 @@ SENTINEL1_LAYER_NAME = "sentinel1"
 # Layer names for historical Sentinel-1 images.
 HISTORICAL_LAYER_NAME = "sentinel1_historical"
 
+# Number of historical item groups the detector consumes (image_1 and image_2).
+HISTORICAL_GROUP_COUNT = 2
+
 # Name of layer containing the output.
 OUTPUT_LAYER_NAME = "output"
 
@@ -412,11 +415,20 @@ def get_vessel_detections(
     )
     with time_operation(TimerOperations.MaterializeDataset):
         materialize_dataset(ds_path, materialize_pipeline_args)
+    # Verify the target image and both historical images were materialized for each
+    # window before running prediction.
     for window in windows:
         if not window.is_layer_completed(SENTINEL1_LAYER_NAME):
             raise ValueError(
                 f"window {window.name} does not have Sentinel-1 layer completed"
             )
+        for group_idx in range(HISTORICAL_GROUP_COUNT):
+            if not window.is_layer_completed(HISTORICAL_LAYER_NAME, group_idx):
+                raise ValueError(
+                    f"window {window.name} is missing historical input image_{group_idx + 1} "
+                    f"({HISTORICAL_LAYER_NAME} group {group_idx}); the detector requires "
+                    f"{HISTORICAL_GROUP_COUNT} historical scenes covering the target"
+                )
 
     # Run object detector.
     with time_operation(TimerOperations.RunModelPredict):


### PR DESCRIPTION
In image-file predict mode (`config_predict_local_files.json`, used by Skylight's sat-service), the `sentinel1_historical` layer had no `space_mode` and inherited the default [`MOSAIC`](https://github.com/allenai/rslearn/blob/8fe9250a78113d831f8c1a6fe346cdd0b9c2487c/rslearn/config/dataset.py#L406). When a historical only partially covers the target (callers accept ≥90% overlap), [MOSAIC merges both historicals into one group](https://github.com/allenai/rslearn/blob/8fe9250a78113d831f8c1a6fe346cdd0b9c2487c/rslearn/data_sources/utils.py#L54) instead of keeping two, so `image_2` is never materialized → the window is dropped → prediction fails with a `FileNotFoundError` on the missing output. Setting `space_mode: INTERSECTS` gives [one group per historical](https://github.com/allenai/rslearn/blob/8fe9250a78113d831f8c1a6fe346cdd0b9c2487c/rslearn/data_sources/utils.py#L202), matching what scene-id mode already does.

Two commits:
1. **Fix:** `space_mode: INTERSECTS` on the historical layer (image-file config only).
2. **Guardrail:** `get_vessel_detections` now verifies both historical groups materialized and raises a clear error instead of the downstream `FileNotFoundError`.

- Only affects image-file mode; scene-id mode (`config.json`) untouched.
- Frames that already succeed are unchanged.
- Config + check only — needs a new sidecar image build to deploy.