### PR TITLE
Sentinel-1 vessels: tile scenes into detector windows to cut materialize memory

### DIFF
--- a/rslp/sentinel1_vessels/predict_pipeline.py
+++ b/rslp/sentinel1_vessels/predict_pipeline.py
@@ -490,20 +490,33 @@ def get_vessel_detections(
     )
     with time_operation(TimerOperations.MaterializeDataset):
         materialize_dataset(ds_path, materialize_pipeline_args)
-    # Verify the target image and both historical images were materialized for each
-    # window before running prediction.
-    for window in windows:
-        if not window.is_layer_completed(SENTINEL1_LAYER_NAME):
+
+    # Keep only tiles that have the target and both historical images materialized. A
+    # scene's bounds form a rectangle around its slanted SAR swath, so tiles over the
+    # nodata margin (or outside the historicals' overlap) never materialize; drop those
+    # tiles, deleting their window so the detector does not read missing layers.
+    complete_windows: list[Window] = []
+    complete_scene_idxs: list[int] = []
+    for window, scene_idx in zip(windows, window_scene_idxs):
+        has_all_layers = window.is_layer_completed(SENTINEL1_LAYER_NAME) and all(
+            window.is_layer_completed(HISTORICAL_LAYER_NAME, group_idx)
+            for group_idx in range(HISTORICAL_GROUP_COUNT)
+        )
+        if has_all_layers:
+            complete_windows.append(window)
+            complete_scene_idxs.append(scene_idx)
+        else:
+            window.window_root.fs.rm(window.window_root.path, recursive=True)
+    windows = complete_windows
+    window_scene_idxs = complete_scene_idxs
+
+    materialized_scene_idxs = set(window_scene_idxs)
+    for scene_idx in range(len(scene_datas)):
+        if scene_idx not in materialized_scene_idxs:
             raise ValueError(
-                f"window {window.name} does not have Sentinel-1 layer completed"
+                f"scene {scene_idx} has no fully-materialized tiles; the detector requires "
+                f"the target and {HISTORICAL_GROUP_COUNT} historical scenes covering it"
             )
-        for group_idx in range(HISTORICAL_GROUP_COUNT):
-            if not window.is_layer_completed(HISTORICAL_LAYER_NAME, group_idx):
-                raise ValueError(
-                    f"window {window.name} is missing historical input image_{group_idx + 1} "
-                    f"({HISTORICAL_LAYER_NAME} group {group_idx}); the detector requires "
-                    f"{HISTORICAL_GROUP_COUNT} historical scenes covering the target"
-                )
 
     # Run object detector.
     with time_operation(TimerOperations.RunModelPredict):

--- a/rslp/sentinel1_vessels/predict_pipeline.py
+++ b/rslp/sentinel1_vessels/predict_pipeline.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import tempfile
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -29,6 +30,7 @@ from upath import UPath
 from rslp.log_utils import get_logger
 from rslp.sentinel1_vessels.prom_metrics import TimerOperations, time_operation
 from rslp.utils.filter import NearInfraFilter
+from rslp.utils.nms import distance_nms
 from rslp.utils.rslearn import (
     ApplyWindowsArgs,
     IngestArgs,
@@ -65,6 +67,15 @@ RESOLUTION = 10
 CROP_WINDOW_SIZE = 128
 # Band order as configured in dataset.
 BAND_NAMES = ["vv", "vh"]
+
+# Side length in pixels of the tiles each scene is split into for detection. Each tile is
+# materialized and run through the detector independently, so peak memory scales with the
+# tile size rather than the full scene.
+DETECTOR_TILE_SIZE = 2048
+
+# Detections in different tiles whose centers are within this many pixels are treated as
+# the same vessel. Matches the detector's within-tile NMS distance threshold.
+SEAM_NMS_DISTANCE_THRESHOLD = 10
 
 # Factor to multiply by when converting bands to 8-bit image.
 NORM_FACTOR = 1.0
@@ -367,6 +378,63 @@ def setup_dataset_with_image_files(
     return scene_datas
 
 
+def _tile_bounds(bounds: PixelBounds, tile_size: int) -> list[PixelBounds]:
+    """Split pixel bounds into a grid of tiles at most ``tile_size`` on each side.
+
+    Args:
+        bounds: the (minx, miny, maxx, maxy) pixel bounds to split.
+        tile_size: maximum side length, in pixels, of each tile.
+
+    Returns:
+        the tile bounds covering ``bounds`` without overlap.
+    """
+    minx, miny, maxx, maxy = bounds
+    tiles: list[PixelBounds] = []
+    for tile_miny in range(miny, maxy, tile_size):
+        for tile_minx in range(minx, maxx, tile_size):
+            tiles.append(
+                (
+                    tile_minx,
+                    tile_miny,
+                    min(tile_minx + tile_size, maxx),
+                    min(tile_miny + tile_size, maxy),
+                )
+            )
+    return tiles
+
+
+def _merge_tile_detections(
+    detections: list[VesselDetection],
+) -> list[VesselDetection]:
+    """Suppress detections duplicated across tiles of the same scene.
+
+    Detections are grouped by scene (``metadata["task_idx"]``) and reduced with distance
+    NMS over their projection-pixel centers, keeping the higher-scoring detection of any
+    pair whose centers fall within ``SEAM_NMS_DISTANCE_THRESHOLD``.
+
+    Args:
+        detections: detections from all tiles, each tagged with its scene index in
+            ``metadata["task_idx"]``.
+
+    Returns:
+        the detections that survive cross-tile suppression.
+    """
+    detections_by_scene: dict[int, list[VesselDetection]] = defaultdict(list)
+    for detection in detections:
+        detections_by_scene[detection.metadata["task_idx"]].append(detection)
+
+    merged: list[VesselDetection] = []
+    for scene_detections in detections_by_scene.values():
+        if len(scene_detections) <= 1:
+            merged.extend(scene_detections)
+            continue
+        centers = np.array([[d.col, d.row] for d in scene_detections], dtype=float)
+        scores = np.array([d.score for d in scene_detections], dtype=float)
+        keep_indices = distance_nms(centers, scores, SEAM_NMS_DISTANCE_THRESHOLD)
+        merged.extend(scene_detections[i] for i in keep_indices)
+    return merged
+
+
 def get_vessel_detections(
     ds_path: UPath,
     scene_datas: list[SceneData],
@@ -381,24 +449,31 @@ def get_vessel_detections(
             detector.
         scene_datas: the SceneDatas to apply the detector on.
     """
-    # Create a window for each SceneData.
+    # Split each scene into a grid of tile windows. Each tile is materialized and run
+    # through the detector independently, so peak memory scales with the tile size rather
+    # than the full scene.
     dataset = Dataset(ds_path)
     windows: list[Window] = []
+    window_scene_idxs: list[int] = []
     group = "detector_predict"
     for scene_idx, scene_data in enumerate(scene_datas):
-        window = Window(
-            storage=dataset.storage,
-            group=group,
-            name=str(scene_idx),
-            projection=scene_data.projection,
-            bounds=scene_data.bounds,
-            time_range=scene_data.time_range,
-        )
-        window.save()
-        windows.append(window)
+        for tile_idx, tile_bounds in enumerate(
+            _tile_bounds(scene_data.bounds, DETECTOR_TILE_SIZE)
+        ):
+            window = Window(
+                storage=dataset.storage,
+                group=group,
+                name=f"{scene_idx}_{tile_idx}",
+                projection=scene_data.projection,
+                bounds=tile_bounds,
+                time_range=scene_data.time_range,
+            )
+            window.save()
+            windows.append(window)
+            window_scene_idxs.append(scene_idx)
 
-        if scene_data.layer_to_item_groups is not None:
-            window.save_layer_datas(scene_data.get_layer_datas())
+            if scene_data.layer_to_item_groups is not None:
+                window.save_layer_datas(scene_data.get_layer_datas())
 
     # Materialize the windows.
     logger.info("Materialize dataset for Sentinel-1 Vessel Detection")
@@ -438,9 +513,10 @@ def get_vessel_detections(
             extra_args=["--data.init_args.num_workers", str(NUM_DATA_LOADER_WORKERS)],
         )
 
-    # Read the detections.
+    # Read the detections from each tile, tagging each with the scene it belongs to.
     detections: list[VesselDetection] = []
-    for task_idx, (window, scene_data) in enumerate(zip(windows, scene_datas)):
+    for window, scene_idx in zip(windows, window_scene_idxs):
+        scene_data = scene_datas[scene_idx]
         layer_dir = window.get_layer_dir(OUTPUT_LAYER_NAME)
         features = GeojsonVectorFormat().decode_vector(
             layer_dir, window.projection, window.bounds
@@ -455,9 +531,9 @@ def get_vessel_detections(
                 row=int(geometry.shp.centroid.y),
                 projection=geometry.projection,
                 score=score,
-                # We use this metadata to keep track of which window/scene each
-                # detection came from.
-                metadata={"task_idx": task_idx},
+                # We use this metadata to keep track of which scene each detection
+                # came from.
+                metadata={"task_idx": scene_idx},
             )
 
             if scene_data.layer_to_item_groups is not None:
@@ -467,7 +543,7 @@ def get_vessel_detections(
 
             detections.append(detection)
 
-    return detections
+    return _merge_tile_detections(detections)
 
 
 def run_attribute_model(

--- a/rslp/utils/nms.py
+++ b/rslp/utils/nms.py
@@ -15,6 +15,69 @@ DEFAULT_GRID_SIZE = 64
 DEFAULT_DISTANCE_THRESHOLD = 10
 
 
+def distance_nms(
+    centers: np.ndarray,
+    scores: np.ndarray,
+    distance_threshold: int,
+    grid_size: int = DEFAULT_GRID_SIZE,
+    indices: np.ndarray | None = None,
+) -> list[int]:
+    """Apply distance-based non-maximum suppression over detection centers.
+
+    Greedily keeps detections in descending score order, eliminating any detection whose
+    center lies within ``distance_threshold`` of an already-kept, higher-scoring one.
+
+    Args:
+        centers: (N, 2) array of (x, y) detection centers.
+        scores: (N,) array of detection scores.
+        distance_threshold: detections within this center distance are considered the
+            same object.
+        grid_size: cell size for the spatial index used to look up nearby centers.
+        indices: original indices for the rows of ``centers``, defaulting to range(N).
+            Returned indices are drawn from this set.
+
+    Returns:
+        the indices of the detections to keep.
+    """
+    if indices is None:
+        indices = np.arange(len(centers))
+
+    grid_index = GridIndex(size=max(grid_size, distance_threshold))
+    for idx, (cx, cy) in zip(indices, centers):
+        grid_index.insert((cx, cy, cx, cy), idx)
+
+    sorted_order = np.argsort(scores)
+    sorted_indices = indices[sorted_order]
+    sorted_centers = centers[sorted_order]
+    sorted_scores = scores[sorted_order]
+
+    elim_inds: set[int] = set()
+    keep_indices: list[int] = []
+    for idx, (cx, cy), score in zip(sorted_indices, sorted_centers, sorted_scores):
+        if idx in elim_inds:
+            continue
+        rect = [
+            cx - distance_threshold,
+            cy - distance_threshold,
+            cx + distance_threshold,
+            cy + distance_threshold,
+        ]
+        for other_idx in grid_index.query(rect):
+            i = np.where(sorted_indices == other_idx)[0][0]
+            if other_idx == idx or other_idx in elim_inds:
+                continue
+            other_score = sorted_scores[i]
+            if other_score > score or (other_score == score and other_idx < idx):
+                other_cx, other_cy = sorted_centers[i]
+                if math.hypot(cx - other_cx, cy - other_cy) <= distance_threshold:
+                    elim_inds.add(idx)
+                    break
+        if idx not in elim_inds:
+            keep_indices.append(idx)
+
+    return keep_indices
+
+
 class NMSDistanceMerger(CropPredictionMerger):
     """Merge predictions by applying distance-based NMS."""
 
@@ -81,24 +144,6 @@ class NMSDistanceMerger(CropPredictionMerger):
 
         return [features[i] for i in keep_indices]
 
-    def _boxes_center_distance(self, box1: np.ndarray, box2: np.ndarray) -> float:
-        """Compute the Euclidean distance between the centers of two boxes.
-
-        Args:
-            box1: numpy array of shape (4,) representing the first bounding box.
-            box2: numpy array of shape (4,) representing the second bounding box.
-
-        Returns:
-            distance: the Euclidean distance between the centers of the two boxes.
-        """
-        cx1 = (box1[0] + box1[2]) / 2
-        cy1 = (box1[1] + box1[3]) / 2
-        cx2 = (box2[0] + box2[2]) / 2
-        cy2 = (box2[1] + box2[3]) / 2
-        dx = cx1 - cx2
-        dy = cy1 - cy2
-        return math.sqrt(dx * dx + dy * dy)
-
     def _apply_nms(
         self, boxes: np.ndarray, scores: np.ndarray, indices: np.ndarray = None
     ) -> list[int]:
@@ -112,46 +157,9 @@ class NMSDistanceMerger(CropPredictionMerger):
         Returns:
             List of indices of boxes to keep.
         """
-        if indices is None:
-            indices = np.arange(len(boxes))
-
-        grid_index = GridIndex(size=max(self.grid_size, self.distance_threshold))
-        for idx, box in zip(indices, boxes):
-            cx = (box[0] + box[2]) / 2
-            cy = (box[1] + box[3]) / 2
-            grid_index.insert((cx, cy, cx, cy), idx)
-
-        sorted_order = np.argsort(scores)
-        sorted_indices = indices[sorted_order]
-        sorted_boxes = boxes[sorted_order]
-        sorted_scores = scores[sorted_order]
-
-        elim_inds = set()
-        keep_indices = []
-        for idx, box, score in zip(sorted_indices, sorted_boxes, sorted_scores):
-            if idx in elim_inds:
-                continue
-            cx = (box[0] + box[2]) / 2
-            cy = (box[1] + box[3]) / 2
-            rect = [
-                cx - self.distance_threshold,
-                cy - self.distance_threshold,
-                cx + self.distance_threshold,
-                cy + self.distance_threshold,
-            ]
-            neighbor_indices = grid_index.query(rect)
-            for other_idx in neighbor_indices:
-                i = np.where(sorted_indices == other_idx)[0][0]
-                if other_idx == idx or other_idx in elim_inds:
-                    continue
-                other_score = sorted_scores[i]
-                if other_score > score or (other_score == score and other_idx < idx):
-                    other_box = sorted_boxes[i]
-                    distance = self._boxes_center_distance(box, other_box)
-                    if distance <= self.distance_threshold:
-                        elim_inds.add(idx)
-                        break
-            if idx not in elim_inds:
-                keep_indices.append(idx)
-
-        return keep_indices
+        centers = np.stack(
+            [(boxes[:, 0] + boxes[:, 2]) / 2, (boxes[:, 1] + boxes[:, 3]) / 2], axis=1
+        )
+        return distance_nms(
+            centers, scores, self.distance_threshold, self.grid_size, indices
+        )


### PR DESCRIPTION
## Motivation

The S1 vessels sidecar OOMs intermittently on large S1C/S1D scenes. The detector runs on a single full-scene `Window`, so `materialize_dataset` builds a full-scene composite (FirstValidCompositor → whole-scene read); measured anon peak ~27 GiB, above an n1-standard-8 node's ~25.9 GiB allocatable → node OOM.

## Change

- Split each scene into a grid of disjoint `DETECTOR_TILE_SIZE` (2048px) detector windows; each tile materializes and runs the detector independently, so peak memory scales with the tile, not the scene.
- Add cross-tile suppression (`_merge_tile_detections`): a vessel near a tile boundary can be detected in two tiles, so dedup by distance NMS per scene. Reuses `distance_nms`, factored out of `NMSDistanceMerger._apply_nms` (behavior unchanged; `merge()` still delegates to it).

Draft: detection-equivalence validation against the full-scene path is pending. See inline notes.