### PR TITLE
make inference endpoint sync

### DIFF
--- a/rslp/sentinel2_vessels/api_main.py
+++ b/rslp/sentinel2_vessels/api_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import threading
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from enum import Enum
@@ -32,6 +33,9 @@ SENTINEL2_PORT = int(os.getenv("SENTINEL2_PORT", 5555))
 
 # Set up the logger
 logger = get_logger(__name__)
+
+# Serializes GPU inference so a single worker only ever runs one prediction at a time.
+_inference_lock = threading.Lock()
 
 
 @asynccontextmanager
@@ -203,9 +207,7 @@ async def home() -> dict:
     summary="Get Vessel Detections from Sentinel-2",
     description="Returns vessel detections from Sentinel-2.",
 )
-async def get_detections(
-    info: Sentinel2Request, response: Response
-) -> Sentinel2Response:
+def get_detections(info: Sentinel2Request, response: Response) -> Sentinel2Response:
     """Returns vessel detections for a given request.
 
     Args:
@@ -238,7 +240,7 @@ async def get_detections(
 
     try:
         logger.info("Processing request with input data.")
-        with time_operation(TimerOperations.TotalInferenceTime):
+        with _inference_lock, time_operation(TimerOperations.TotalInferenceTime):
             vessel_detections = predict_pipeline(
                 tasks=[task],
                 scratch_path=scratch_path,


### PR DESCRIPTION
the main change here is making the `get_detections` http endpoint be a synchronous endpoint rather than `async`.   

Because the `get_detections` method was marked as `async`, but contained no actual async code, when it ran it blocked the entire `asyncio` event loop.  Meaning that the server could only handle a single request at a time effectively. 

In production we run a healthcheck that ensures the api is up and responding to requests, in order to have a worker respond to those healthchecks while we also ran inference, we had to run fastapi in multi-process mode with `WEB_CONCURRENCY=2` 

However, that change caused uvicorn to become a multi-worker supervisor: a parent process that spawns N worker subprocesses and manages their lifecycle. That supervisor path was crash-looping in production: 

The logs showed:

```
  Started parent process [1]
  Waiting for child process [26]
  Child process [26] died      ← worker dies during bootstrap, before binding :5555
  ... (repeats hundreds of times, never reaching "Started server process")
```

I have built this image and am running it in production ;we're seeing about 2x the throughput already with just this change. 