### PR TITLE
rslp.common infrastructure updates

### DIFF
--- a/rslp/common/beaker_launcher.py
+++ b/rslp/common/beaker_launcher.py
@@ -3,7 +3,13 @@
 import uuid
 from datetime import datetime
 
-from beaker import Beaker, BeakerEnvVar, BeakerExperimentSpec, BeakerImageSource
+from beaker import (
+    Beaker,
+    BeakerConstraints,
+    BeakerEnvVar,
+    BeakerExperimentSpec,
+    BeakerImageSource,
+)
 from beaker.exceptions import BeakerImageNotFound
 
 from rslp.log_utils import get_logger
@@ -36,12 +42,14 @@ def get_command(project: str, workflow: str, extra_args: list[str]) -> list[str]
 
 
 def launch_job(
-    project: str,
-    workflow: str,
-    extra_args: list[str],
     image: str,
-    clusters: list[str],
-    task_name: str | None,
+    clusters: list[str] | None = None,
+    hostname: str | None = None,
+    project: str | None = None,
+    workflow: str | None = None,
+    extra_args: list[str] = [],
+    command: list[str] | None = None,
+    task_name: str | None = None,
     gpu_count: int = 0,
     shared_memory: str | None = None,
     priority: str = DEFAULT_PRIORITY,
@@ -51,19 +59,28 @@ def launch_job(
     preemptible: bool = True,
     weka_mounts: list[WekaMount] = [],
 ) -> None:
-    """Launch a Beaker job to run an rslp workflow.
+    """Launch a Beaker job to run an rslp workflow or an arbitrary command.
 
     The BEAKER_ADDR, BEAKER_CONFIG, and BEAKER_TOKEN environment variables must be
     configured.
 
+    The job's command is either ``command`` (run verbatim) or, if ``command`` is not
+    set, the rslp workflow indicated by ``project``/``workflow``/``extra_args``. Exactly
+    one of these two modes must be specified.
+
     Args:
-        project: the rslp project containing the workflow(s) to run.
-        workflow: the workflow to run.
-        extra_args: a list of arguments for the workflow.
         image: the name of the Beaker image to use. If it doesn't exist, we look for a
             local Docker image matching this name and attempt to register it into
             Beaker.
-        clusters: list of Beaker clusters to target.
+        clusters: list of Beaker clusters to target. Exactly one of clusters or
+            hostname must be set.
+        hostname: a specific Beaker host to constrain the job to. Exactly one of
+            clusters or hostname must be set.
+        project: the rslp project containing the workflow to run (workflow mode).
+        workflow: the workflow to run (workflow mode).
+        extra_args: a list of arguments for the workflow (workflow mode).
+        command: an arbitrary command to run instead of an rslp workflow. If set,
+            project/workflow/extra_args are ignored.
         task_name: name for the Beaker job.
         gpu_count: number of GPUs to assign.
         shared_memory: amount of shared memory.
@@ -75,8 +92,18 @@ def launch_job(
         preemptible: whether to make the Beaker job preemptible.
         weka_mounts: list of weka mounts for Beaker job.
     """
+    if command is None:
+        if project is None or workflow is None:
+            raise ValueError("must set either command or both project and workflow")
+        command = get_command(project, workflow, extra_args)
+    if (clusters is None) == (hostname is None):
+        raise ValueError("exactly one of clusters or hostname must be set")
+
     if task_name is None:
-        task_name = f"{project}_{workflow}"
+        if project is not None and workflow is not None:
+            task_name = f"{project}_{workflow}"
+        else:
+            task_name = "command"
 
     logger.info("Starting Beaker client...")
     logger.info(f"Workspace: {workspace}")
@@ -101,14 +128,18 @@ def launch_job(
         logger.info("Creating experiment spec...")
         datasets = [create_gcp_credentials_mount()]
         datasets += [weka_mount.to_data_mount() for weka_mount in weka_mounts]
+        if hostname is not None:
+            constraints = BeakerConstraints(hostname=[hostname])
+        else:
+            constraints = BeakerConstraints(cluster=clusters)
         experiment_spec = BeakerExperimentSpec.new(
             budget=budget,
             task_name=unique_task_name,
             beaker_image=image_source.beaker,
             result_path="/models",
             priority=priority,
-            cluster=clusters,
-            command=get_command(project, workflow, extra_args),
+            constraints=constraints,
+            command=command,
             env_vars=base_env_vars + task_specific_env_vars,
             datasets=datasets,
             resources={"gpuCount": gpu_count, "sharedMemory": shared_memory},

--- a/rslp/common/beaker_train.py
+++ b/rslp/common/beaker_train.py
@@ -43,6 +43,7 @@ def beaker_train(
     priority: str = "high",
     retries: int = 0,
     extra_env_vars: dict[str, str] = {},
+    extra_env_secrets: dict[str, str] = {},
 ) -> None:
     """Launch training for the specified config on Beaker.
 
@@ -69,6 +70,9 @@ def beaker_train(
         priority: the priority to assign to the Beaker job.
         retries: how many times to retry the Beaker job.
         extra_env_vars: additional environment variables to set in the Beaker job.
+        extra_env_secrets: additional environment variables to set in the Beaker job
+            from Beaker secrets, mapping environment variable name to the name of the
+            Beaker secret (in the target workspace) to read its value from.
     """
     # Normalize the config_path / config_paths option to always get a config_paths list
     # (so if config_path is set, make a one-element list from it).
@@ -147,6 +151,14 @@ def beaker_train(
                     BeakerEnvVar(
                         name=env_name,
                         value=env_value,
+                    )
+                )
+
+            for env_name, secret_name in extra_env_secrets.items():
+                env_vars.append(
+                    BeakerEnvVar(
+                        name=env_name,
+                        secret=secret_name,
                     )
                 )
 

--- a/rslp/common/beaker_train.py
+++ b/rslp/common/beaker_train.py
@@ -43,7 +43,7 @@ def beaker_train(
     priority: str = "high",
     retries: int = 0,
     extra_env_vars: dict[str, str] = {},
-    extra_env_secrets: dict[str, str] = {},
+    extra_env_secrets: dict[str, str] | None = None,
 ) -> None:
     """Launch training for the specified config on Beaker.
 
@@ -76,6 +76,8 @@ def beaker_train(
     """
     # Normalize the config_path / config_paths option to always get a config_paths list
     # (so if config_path is set, make a one-element list from it).
+    if extra_env_secrets is None:
+        extra_env_secrets = {}
     if (config_path is None and config_paths is None) or (
         config_path is not None and config_paths is not None
     ):

--- a/rslp/common/worker.py
+++ b/rslp/common/worker.py
@@ -12,6 +12,7 @@ import tqdm
 from beaker import (
     Beaker,
     BeakerConstraints,
+    BeakerEnvVar,
     BeakerExperimentSpec,
     BeakerJobPriority,
     BeakerTaskResources,
@@ -133,6 +134,7 @@ def launch_workers(
     shared_memory: str | None = None,
     priority: BeakerJobPriority = BeakerJobPriority.low,
     weka_mounts: list[WekaMount] = [],
+    extra_env_vars: list[dict] = [],
 ) -> None:
     """Start workers for the prediction jobs.
 
@@ -145,10 +147,15 @@ def launch_workers(
         shared_memory: shared memory string like "256GiB".
         priority: priority to assign the Beaker jobs.
         weka_mounts: list of weka mounts for Beaker job.
+        extra_env_vars: additional environment variables to set on each worker, beyond
+            the base env vars. Each entry is a dict passed to BeakerEnvVar, e.g.
+            {"name": "FOO", "value": "bar"} or {"name": "FOO", "secret": "MY_SECRET"}.
     """
+    extra_beaker_env_vars = [BeakerEnvVar(**ev) for ev in extra_env_vars]
     with Beaker.from_env(default_workspace=DEFAULT_WORKSPACE) as beaker:
         for _ in tqdm.tqdm(range(num_workers)):
             env_vars = get_base_env_vars(use_weka_prefix=False)
+            env_vars += extra_beaker_env_vars
 
             datasets = [create_gcp_credentials_mount()]
             datasets += [weka_mount.to_data_mount() for weka_mount in weka_mounts]

--- a/rslp/common/worker.py
+++ b/rslp/common/worker.py
@@ -134,7 +134,8 @@ def launch_workers(
     shared_memory: str | None = None,
     priority: BeakerJobPriority = BeakerJobPriority.low,
     weka_mounts: list[WekaMount] = [],
-    extra_env_vars: list[dict] = [],
+    extra_env_vars: dict[str, str] | None = None,
+    extra_env_secrets: dict[str, str] | None = None,
 ) -> None:
     """Start workers for the prediction jobs.
 
@@ -148,10 +149,23 @@ def launch_workers(
         priority: priority to assign the Beaker jobs.
         weka_mounts: list of weka mounts for Beaker job.
         extra_env_vars: additional environment variables to set on each worker, beyond
-            the base env vars. Each entry is a dict passed to BeakerEnvVar, e.g.
-            {"name": "FOO", "value": "bar"} or {"name": "FOO", "secret": "MY_SECRET"}.
+            the base env vars, mapping environment variable name to its plain value.
+        extra_env_secrets: additional environment variables to set on each worker from
+            Beaker secrets, mapping environment variable name to the name of the Beaker
+            secret (in the target workspace) to read its value from.
     """
-    extra_beaker_env_vars = [BeakerEnvVar(**ev) for ev in extra_env_vars]
+    if extra_env_vars is None:
+        extra_env_vars = {}
+    if extra_env_secrets is None:
+        extra_env_secrets = {}
+    extra_beaker_env_vars = [
+        BeakerEnvVar(name=env_name, value=env_value)
+        for env_name, env_value in extra_env_vars.items()
+    ]
+    extra_beaker_env_vars += [
+        BeakerEnvVar(name=env_name, secret=secret_name)
+        for env_name, secret_name in extra_env_secrets.items()
+    ]
     with Beaker.from_env(default_workspace=DEFAULT_WORKSPACE) as beaker:
         for _ in tqdm.tqdm(range(num_workers)):
             env_vars = get_base_env_vars(use_weka_prefix=False)

--- a/rslp/olmoearth_evals/eval_adapter.py
+++ b/rslp/olmoearth_evals/eval_adapter.py
@@ -1,6 +1,7 @@
 """Adapter for evaluation tasks."""
 
 import os
+from types import ModuleType
 from typing import Any
 
 import torch
@@ -13,7 +14,6 @@ from rslearn.train.transforms.transform import Transform
 
 import rslp.olmoearth_evals.aef as aef
 import rslp.olmoearth_evals.anysat as anysat
-import rslp.olmoearth_evals.clay as clay
 import rslp.olmoearth_evals.croma as croma
 import rslp.olmoearth_evals.dinov3 as dinov3
 import rslp.olmoearth_evals.galileo as galileo
@@ -23,11 +23,21 @@ import rslp.olmoearth_evals.panopticon as panopticon
 import rslp.olmoearth_evals.presto as presto
 import rslp.olmoearth_evals.prithvi as prithvi
 import rslp.olmoearth_evals.satlaspretrain as satlaspretrain
-import rslp.olmoearth_evals.terramind as terramind
+
+# clay and terramind import terratorch (an optional dependency), so guard them:
+# if terratorch is not installed, these models are simply unavailable and any
+# other model (e.g. olmoearth) still works.
+clay: ModuleType | None
+terramind: ModuleType | None
+try:
+    import rslp.olmoearth_evals.clay as clay
+    import rslp.olmoearth_evals.terramind as terramind
+except ImportError:
+    clay = None
+    terramind = None
 
 modules_by_model_id = {
     "anysat": anysat,
-    "clay": clay,
     "croma": croma,
     "croma_large": croma,
     "dinov3": dinov3,
@@ -43,10 +53,13 @@ modules_by_model_id = {
     "presto": presto,
     "prithvi": prithvi,
     "satlaspretrain": satlaspretrain,
-    "terramind": terramind,
-    "terramind_large": terramind,
     "aef": aef,
 }
+if clay is not None:
+    modules_by_model_id["clay"] = clay
+if terramind is not None:
+    modules_by_model_id["terramind"] = terramind
+    modules_by_model_id["terramind_large"] = terramind
 
 # Task key used in MultiTask for eval configs; target rasters live under target/<key>/...
 EVAL_TASK_KEY = "eval_task"

--- a/rslp/olmoearth_evals/launch.py
+++ b/rslp/olmoearth_evals/launch.py
@@ -76,7 +76,7 @@ def launch(
     use_embeddings: bool = False,
     model_config: dict[str, str] | None = None,
     extra_args: list[str] = [],
-    extra_env_secrets: dict[str, str] = {},
+    extra_env_secrets: dict[str, str] | None = None,
     freeze: str = "freezefor20_lrfactor1",
 ) -> None:
     """Launch OlmoEarth fine-tuning evaluation.

--- a/rslp/olmoearth_evals/launch.py
+++ b/rslp/olmoearth_evals/launch.py
@@ -76,6 +76,7 @@ def launch(
     use_embeddings: bool = False,
     model_config: dict[str, str] | None = None,
     extra_args: list[str] = [],
+    extra_env_secrets: dict[str, str] = {},
     freeze: str = "freezefor20_lrfactor1",
 ) -> None:
     """Launch OlmoEarth fine-tuning evaluation.
@@ -100,6 +101,9 @@ def launch(
             {"checkpoint_path": "/path/to/ckpt"} to load a custom checkpoint,
             {"use_legacy_timestamps": "true"} to enable legacy timestamps.
         extra_args: extra arguments to pass to `rslearn model fit`.
+        extra_env_secrets: additional environment variables to set in each Beaker job
+            from Beaker secrets, mapping environment variable name to the name of the
+            Beaker secret (in the target workspace), e.g. {"HF_TOKEN": "HF_TOKEN"}.
         freeze: name of a freeze config in data/olmoearth_evals/freezes/ (without
             the .yaml extension), e.g. "freezefor20_lrfactor1" or "frozen". The
             corresponding YAML adds a FreezeUnfreeze callback that freezes the
@@ -139,6 +143,10 @@ def launch(
                 "--extra_env_vars",
                 json.dumps(env_vars_dict),
             ]
+            if extra_env_secrets:
+                basic_args.extend(
+                    ["--extra_env_secrets", json.dumps(extra_env_secrets)]
+                )
 
             cluster_args = [f"--cluster+={cluster}" for cluster in clusters]
 


### PR DESCRIPTION
Depends on https://github.com/allenai/rslearn_projects/pull/309

rslp.common:
- beaker_launcher: support setting the command to run in the container directly as an
  alternative to setting the project and workflow.
- beaker_train and worker: support setting environment variables from secrets. This way
  can add things like olmoearth_datasets token.

rslp.olmoearth_evals:
- Make clay and terramind optional since they are not included in rslearn[extra] anymore.
- Support env secrets in launcher. This could be used for Hugging Face token.