### PR TITLE
remove compression for sentinel2 vessels local files

### DIFF
--- a/data/sentinel2_vessels/config_predict_local_files.json
+++ b/data/sentinel2_vessels/config_predict_local_files.json
@@ -43,6 +43,14 @@
               1000,
               11000
             ]
+          },
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
           }
         },
         {
@@ -66,7 +74,15 @@
               11000
             ]
           },
-          "zoom_offset": -1
+          "zoom_offset": -1,
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
+          }
         },
         {
           "bands": [
@@ -86,7 +102,15 @@
               11000
             ]
           },
-          "zoom_offset": -2
+          "zoom_offset": -2,
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
+          }
         }
       ],
       "data_source": {
@@ -97,6 +121,14 @@
         }
       },
       "type": "raster"
+    }
+  },
+  "tile_store": {
+    "class_path": "rslearn.tile_stores.default.DefaultTileStore",
+    "init_args": {
+      "geotiff_options": {
+        "compress": "none"
+      }
     }
   }
 }

--- a/data/sentinel2_vessels/config_predict_local_files.json
+++ b/data/sentinel2_vessels/config_predict_local_files.json
@@ -33,6 +33,14 @@
             "B08"
           ],
           "dtype": "uint16",
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
+          },
           "remap": {
             "dst": [
               0,
@@ -43,14 +51,6 @@
               1000,
               11000
             ]
-          },
-          "format": {
-            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
-            "init_args": {
-              "geotiff_options": {
-                "compress": "none"
-              }
-            }
           }
         },
         {
@@ -63,6 +63,14 @@
             "B12"
           ],
           "dtype": "uint16",
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
+          },
           "remap": {
             "dst": [
               0,
@@ -74,15 +82,7 @@
               11000
             ]
           },
-          "zoom_offset": -1,
-          "format": {
-            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
-            "init_args": {
-              "geotiff_options": {
-                "compress": "none"
-              }
-            }
-          }
+          "zoom_offset": -1
         },
         {
           "bands": [
@@ -91,6 +91,14 @@
             "B10"
           ],
           "dtype": "uint16",
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
+          },
           "remap": {
             "dst": [
               0,
@@ -102,15 +110,7 @@
               11000
             ]
           },
-          "zoom_offset": -2,
-          "format": {
-            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
-            "init_args": {
-              "geotiff_options": {
-                "compress": "none"
-              }
-            }
-          }
+          "zoom_offset": -2
         }
       ],
       "data_source": {


### PR DESCRIPTION
Drops compression from the local tile store used for sentinel 2 vessel detection,  Because we are actually reading/writing the images a couple times, this drops ~80 seconds from materialization, which is considerable. 

```
These rasters are scratch — nothing reads them except the model, immediately, on the same box. 
And LZW was barely compressing them anyway: 1357 MB vs 1372 MB of raw pixels, 
~1% saved for 38 s of encode time.

  ┌────────────────────┬────────┬────────┬─────────┬────────────┐
  │       codec        │ encode │ decode │  size   │ end-to-end │
  ├────────────────────┼────────┼────────┼─────────┼────────────┤
  │ lzw (current)      │ 29.9 s │ 11.0 s │ 1182 MB │ 169.9 s    │
  ├────────────────────┼────────┼────────┼─────────┼────────────┤
  │ zstd 1 + predictor │ 5.0 s  │ 5.0 s  │ 918 MB  │ 106.9 s    │
  ├────────────────────┼────────┼────────┼─────────┼────────────┤
  │ none               │ 1.6 s  │ 1.3 s  │ 1375 MB │ 93.8 s     │
  └────────────────────┴────────┴────────┴─────────┴────────────┘

Uncompressed beats zstd because zstd's encode + decode costs more than moving the extra bytes does.

The trade-off is scratch space: 2827 MB per scene vs 1849 MB for zstd (+978 MB). 
```

Most of the remaining time is doing the jpeg2000 read; which is a larger thing to change;  But this is hopefully a small / quick win. 