### PR TITLE
Add large-scale GeoZarr embedding output with supervised runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 **/.direnv
 **/__pycache__
 **/.mypy_cache
+**/*.egg-info
+.venv
 .env
 lightning_logs
 wandb

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docker_build
 
 # misc from one off projects
 one_off_projects/2025_07_joint_finetune/data
+*.egg-info/

--- a/data/large_scale_embeddings/initial_regions.geojson
+++ b/data/large_scale_embeddings/initial_regions.geojson
@@ -1,0 +1,179 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -124.8,
+              45.5
+            ],
+            [
+              -116.9,
+              45.5
+            ],
+            [
+              -116.9,
+              49.0
+            ],
+            [
+              -124.8,
+              49.0
+            ],
+            [
+              -124.8,
+              45.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "name": "washington"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -116.05,
+              44.35
+            ],
+            [
+              -104.04,
+              44.35
+            ],
+            [
+              -104.04,
+              49.0
+            ],
+            [
+              -116.05,
+              49.0
+            ],
+            [
+              -116.05,
+              44.35
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "name": "montana"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              22.1,
+              44.3
+            ],
+            [
+              40.2,
+              44.3
+            ],
+            [
+              40.2,
+              52.4
+            ],
+            [
+              22.1,
+              52.4
+            ],
+            [
+              22.1,
+              44.3
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "name": "ukraine"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              97.3,
+              20.4
+            ],
+            [
+              97.3,
+              14.5
+            ],
+            [
+              98.0,
+              14.5
+            ],
+            [
+              98.0,
+              5.6
+            ],
+            [
+              102.5,
+              5.6
+            ],
+            [
+              102.5,
+              14.5
+            ],
+            [
+              105.6,
+              14.5
+            ],
+            [
+              105.6,
+              20.4
+            ],
+            [
+              97.3,
+              20.4
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "name": "thailand"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          -45.0,
+          72.0
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "name": "greenland_point"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          110.5,
+          -66.28
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "name": "antarctica_coast_point"
+      },
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/data/large_scale_embeddings/pastis.geojson
+++ b/data/large_scale_embeddings/pastis.geojson
@@ -1,0 +1,141 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.67,
+              48.58
+            ],
+            [
+              -0.08,
+              48.58
+            ],
+            [
+              -0.08,
+              49.69
+            ],
+            [
+              -1.67,
+              49.69
+            ],
+            [
+              -1.67,
+              48.58
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "description": "PASTIS / PASTIS-R patches in Sentinel-2 tile T30UXV (Brittany, France), with margin.",
+        "name": "pastis_t30uxv"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              4.22,
+              43.21
+            ],
+            [
+              5.66,
+              43.21
+            ],
+            [
+              5.66,
+              44.29
+            ],
+            [
+              4.22,
+              44.29
+            ],
+            [
+              4.22,
+              43.21
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "description": "PASTIS / PASTIS-R patches in Sentinel-2 tile T31TFJ (Provence, France), with margin.",
+        "name": "pastis_t31tfj"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              4.25,
+              45.89
+            ],
+            [
+              5.78,
+              45.89
+            ],
+            [
+              5.78,
+              46.99
+            ],
+            [
+              4.25,
+              46.99
+            ],
+            [
+              4.25,
+              45.89
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "description": "PASTIS / PASTIS-R patches in Sentinel-2 tile T31TFM (Burgundy, France), with margin.",
+        "name": "pastis_t31tfm"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              6.23,
+              47.68
+            ],
+            [
+              7.83,
+              47.68
+            ],
+            [
+              7.83,
+              48.8
+            ],
+            [
+              6.23,
+              48.8
+            ],
+            [
+              6.23,
+              47.68
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": {
+        "description": "PASTIS / PASTIS-R patches in Sentinel-2 tile T32ULU (Alsace, France), with margin.",
+        "name": "pastis_t32ulu"
+      },
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/data/large_scale_embeddings/s2.json
+++ b/data/large_scale_embeddings/s2.json
@@ -4,6 +4,14 @@
       "band_sets": [
         {
           "dtype": "int8",
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
+          },
           "num_bands": 128
         }
       ],
@@ -42,8 +50,7 @@
           "query": {
             "sort_by": "CLOUD_COVER",
             "sort_direction": "ASC"
-          },
-          "timeout": "0:0:10"
+          }
         },
         "query_config": {
           "max_matches": 12,

--- a/data/large_scale_embeddings/s2.json
+++ b/data/large_scale_embeddings/s2.json
@@ -1,0 +1,59 @@
+{
+  "layers": {
+    "output": {
+      "band_sets": [
+        {
+          "dtype": "int8",
+          "num_bands": 128
+        }
+      ],
+      "type": "raster"
+    },
+    "sentinel2_l2a": {
+      "band_sets": [
+        {
+          "bands": [
+            "B01",
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B09",
+            "B11",
+            "B12"
+          ],
+          "dtype": "uint16"
+        }
+      ],
+      "data_source": {
+        "class_path": "olmoearth_run.runner.tools.rslearn_data_sources.olmoearth_datasets.sentinel2_l2a.Sentinel2L2A",
+        "duration": "365d",
+        "ingest": false,
+        "init_args": {
+          "cache_dir": "cache/olmoearth_datasets",
+          "harmonize": true,
+          "provider_excludes": [
+            "AWS_SENTINEL_2_L2A_COGS"
+          ],
+          "query": {
+            "sort_by": "CLOUD_COVER",
+            "sort_direction": "ASC"
+          },
+          "timeout": "0:0:10"
+        },
+        "query_config": {
+          "max_matches": 12,
+          "min_matches": 1,
+          "period_duration": "30d",
+          "space_mode": "MOSAIC"
+        },
+        "time_offset": "0d"
+      },
+      "type": "raster"
+    }
+  }
+}

--- a/data/large_scale_embeddings/s2.yaml
+++ b/data/large_scale_embeddings/s2.yaml
@@ -1,0 +1,70 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.singletask.SingleTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
+            init_args:
+              checkpoint_path: /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+              # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
+              patch_size: 1
+              embedding_size: 128
+              # Normalize raw Sentinel-2 values inside the encoder.
+              normalize: true
+              autocast_dtype: bfloat16
+              # Use the actual mosaic timestamps (from the materialized layer
+              # metadata) rather than dummy monthly timestamps. This also pads
+              # samples with differing numbers of mosaics so they can be batched
+              # together.
+              use_legacy_timestamps: false
+        decoder:
+          # L2-normalizes each pixel's embedding and quantizes it to int8 using the
+          # AlphaEarth-style power scheme (-128 is reserved for nodata).
+          - class_path: rslp.large_scale_embeddings.model.QuantizedEmbeddingHead
+            init_args:
+              l2_normalize: true
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    # Overridden by the prediction pipeline via --data.init_args.path.
+    path: placeholder
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2_l2a"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+        load_all_item_groups: true
+    task:
+      # Inference-only task: no targets/loss; writes the head's int8 output.
+      class_path: rslearn.train.tasks.embedding.EmbeddingTask
+    # Crops are tiny (16x16) so a large batch size is needed for throughput. Tune
+    # per GPU along with num_workers.
+    batch_size: 64
+    num_workers: 16
+    default_config:
+      # The model must operate on 16x16 crops; anything bigger fails with the 12
+      # monthly inputs at patch_size=1 due to GPU memory constraints.
+      crop_size: 16
+    predict_config:
+      load_all_crops: true
+      # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
+      # RasterMerger below trims half the overlap from each crop when merging.
+      overlap_pixels: 8
+      skip_targets: true
+trainer:
+  callbacks:
+    # Writes the int8 128-band embedding raster to the "output" layer.
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        output_layer: output
+        selector: []
+        merger:
+          class_path: rslearn.train.prediction_writer.RasterMerger
+          init_args:
+            downsample_factor: 1
+            overlap_pixels: 8

--- a/data/large_scale_embeddings/s2.yaml
+++ b/data/large_scale_embeddings/s2.yaml
@@ -7,7 +7,9 @@ model:
         encoder:
           - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
             init_args:
-              checkpoint_path: /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+              # The OlmoEarth checkpoint to compute embeddings with, e.g.
+              # /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+              checkpoint_path: ${CHECKPOINT_PATH}
               # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
               patch_size: 1
               embedding_size: 128
@@ -23,10 +25,11 @@ model:
               # samples with differing numbers of mosaics so they can be batched
               # together.
               use_legacy_timestamps: false
-              # Compile the encoder transformer blocks (the register bottleneck
-              # stays eager). Inference uses fixed 16x16 crops so recompilations
-              # are limited to the few distinct batch/timestep shapes.
-              compile_model: true
+              # Whether to compile the encoder transformer blocks (the register
+              # bottleneck stays eager). Inference uses fixed WINDOW_SIZE crops so
+              # recompilations are limited to the few distinct batch/timestep
+              # shapes.
+              compile_model: ${COMPILE_MODEL}
         decoder:
           # L2-normalizes each pixel's embedding and quantizes it to int8 using the
           # AlphaEarth-style power scheme (-128 is reserved for nodata).
@@ -50,19 +53,20 @@ data:
     task:
       # Inference-only task: no targets/loss; writes the head's int8 output.
       class_path: rslearn.train.tasks.embedding.EmbeddingTask
-    # Crops are tiny (16x16) so a large batch size is needed for throughput. Tune
-    # per GPU along with num_workers.
+    # Crops are tiny (e.g. 16x16) so a large batch size is needed for throughput.
+    # Tune per GPU along with num_workers.
     batch_size: 256
     num_workers: 16
     default_config:
-      # The model must operate on 16x16 crops; anything bigger fails with the 12
-      # monthly inputs at patch_size=1 due to GPU memory constraints.
-      crop_size: 16
+      # The size of the crops the model operates on, e.g. 16 (much bigger fails
+      # with the 12 monthly inputs at patch_size=1 due to GPU memory constraints).
+      crop_size: ${WINDOW_SIZE}
     predict_config:
       load_all_crops: true
       # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
       # RasterMerger below trims half the overlap from each crop when merging.
-      overlap_pixels: 4
+      # Must match the RasterMerger overlap_pixels.
+      overlap_pixels: ${OVERLAP_SIZE}
       skip_targets: true
 trainer:
   callbacks:
@@ -75,4 +79,5 @@ trainer:
           class_path: rslearn.train.prediction_writer.RasterMerger
           init_args:
             downsample_factor: 1
-            overlap_pixels: 4
+            # Must match the predict_config overlap_pixels.
+            overlap_pixels: ${OVERLAP_SIZE}

--- a/data/large_scale_embeddings/s2.yaml
+++ b/data/large_scale_embeddings/s2.yaml
@@ -11,6 +11,10 @@ model:
               # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
               patch_size: 1
               embedding_size: 128
+              # Output the 128-dim spatial register bottleneck latents (one per
+              # patch in dynamic-grid mode) rather than the 768-dim encoder patch
+              # tokens.
+              use_register_bottleneck_output: true
               # Normalize raw Sentinel-2 values inside the encoder.
               normalize: true
               autocast_dtype: bfloat16
@@ -19,6 +23,10 @@ model:
               # samples with differing numbers of mosaics so they can be batched
               # together.
               use_legacy_timestamps: false
+              # Compile the encoder transformer blocks (the register bottleneck
+              # stays eager). Inference uses fixed 16x16 crops so recompilations
+              # are limited to the few distinct batch/timestep shapes.
+              compile_model: true
         decoder:
           # L2-normalizes each pixel's embedding and quantizes it to int8 using the
           # AlphaEarth-style power scheme (-128 is reserved for nodata).
@@ -44,7 +52,7 @@ data:
       class_path: rslearn.train.tasks.embedding.EmbeddingTask
     # Crops are tiny (16x16) so a large batch size is needed for throughput. Tune
     # per GPU along with num_workers.
-    batch_size: 64
+    batch_size: 256
     num_workers: 16
     default_config:
       # The model must operate on 16x16 crops; anything bigger fails with the 12
@@ -54,7 +62,7 @@ data:
       load_all_crops: true
       # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
       # RasterMerger below trims half the overlap from each crop when merging.
-      overlap_pixels: 8
+      overlap_pixels: 4
       skip_targets: true
 trainer:
   callbacks:
@@ -67,4 +75,4 @@ trainer:
           class_path: rslearn.train.prediction_writer.RasterMerger
           init_args:
             downsample_factor: 1
-            overlap_pixels: 8
+            overlap_pixels: 4

--- a/data/large_scale_embeddings/s2.yaml
+++ b/data/large_scale_embeddings/s2.yaml
@@ -8,9 +8,12 @@ model:
           - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
             init_args:
               # The OlmoEarth checkpoint to compute embeddings with, e.g.
-              # /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
-              checkpoint_path: ${CHECKPOINT_PATH}
+              # /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000.
+              # This placeholder is always overridden by the prediction pipeline
+              # (--checkpoint_path).
+              checkpoint_path: /path/to/checkpoint_dir
               # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
+              # Overridden by the prediction pipeline (--patch_size).
               patch_size: 1
               embedding_size: 128
               # Output the 128-dim spatial register bottleneck latents (one per
@@ -26,10 +29,10 @@ model:
               # together.
               use_legacy_timestamps: false
               # Whether to compile the encoder transformer blocks (the register
-              # bottleneck stays eager). Inference uses fixed WINDOW_SIZE crops so
+              # bottleneck stays eager). Inference uses fixed-size crops so
               # recompilations are limited to the few distinct batch/timestep
-              # shapes.
-              compile_model: ${COMPILE_MODEL}
+              # shapes. Overridden by the prediction pipeline (--compile_model).
+              compile_model: true
         decoder:
           # L2-normalizes each pixel's embedding and quantizes it to int8 using the
           # AlphaEarth-style power scheme (-128 is reserved for nodata).
@@ -58,15 +61,17 @@ data:
     batch_size: 256
     num_workers: 16
     default_config:
-      # The size of the crops the model operates on, e.g. 16 (much bigger fails
-      # with the 12 monthly inputs at patch_size=1 due to GPU memory constraints).
-      crop_size: ${WINDOW_SIZE}
+      # The size of the crops the model operates on (much bigger fails with the 12
+      # monthly inputs at patch_size=1 due to GPU memory constraints). Overridden
+      # by the prediction pipeline (--window_size).
+      crop_size: 16
     predict_config:
       load_all_crops: true
       # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
       # RasterMerger below trims half the overlap from each crop when merging.
-      # Must match the RasterMerger overlap_pixels.
-      overlap_pixels: ${OVERLAP_SIZE}
+      # Must match the RasterMerger overlap_pixels (times patch_size). Overridden
+      # by the prediction pipeline (--overlap_size).
+      overlap_pixels: 4
       skip_targets: true
 trainer:
   callbacks:
@@ -78,6 +83,10 @@ trainer:
         merger:
           class_path: rslearn.train.prediction_writer.RasterMerger
           init_args:
+            # Must match the encoder patch_size. Overridden by the prediction
+            # pipeline (--patch_size).
             downsample_factor: 1
-            # Must match the predict_config overlap_pixels.
-            overlap_pixels: ${OVERLAP_SIZE}
+            # Must be the predict_config overlap_pixels divided by the encoder
+            # patch_size (the merger operates at the output resolution).
+            # Overridden by the prediction pipeline.
+            overlap_pixels: 4

--- a/data/large_scale_embeddings/s2_s1.json
+++ b/data/large_scale_embeddings/s2_s1.json
@@ -1,0 +1,86 @@
+{
+  "layers": {
+    "output": {
+      "band_sets": [
+        {
+          "dtype": "int8",
+          "num_bands": 128
+        }
+      ],
+      "type": "raster"
+    },
+    "sentinel1": {
+      "band_sets": [
+        {
+          "bands": [
+            "vv",
+            "vh"
+          ],
+          "dtype": "float32"
+        }
+      ],
+      "data_source": {
+        "class_path": "olmoearth_run.runner.tools.rslearn_data_sources.olmoearth_datasets.sentinel1_rtc.Sentinel1RTC",
+        "duration": "365d",
+        "ingest": false,
+        "init_args": {
+          "timeout": "0:0:10"
+        },
+        "query_config": {
+          "max_matches": 12,
+          "min_matches": 1,
+          "period_duration": "30d",
+          "space_mode": "MOSAIC"
+        },
+        "time_offset": "0d"
+      },
+      "type": "raster"
+    },
+    "sentinel2_l2a": {
+      "band_sets": [
+        {
+          "bands": [
+            "B01",
+            "B02",
+            "B03",
+            "B04",
+            "B05",
+            "B06",
+            "B07",
+            "B08",
+            "B8A",
+            "B09",
+            "B11",
+            "B12"
+          ],
+          "dtype": "uint16"
+        }
+      ],
+      "data_source": {
+        "class_path": "olmoearth_run.runner.tools.rslearn_data_sources.olmoearth_datasets.sentinel2_l2a.Sentinel2L2A",
+        "duration": "365d",
+        "ingest": false,
+        "init_args": {
+          "cache_dir": "cache/olmoearth_datasets",
+          "harmonize": true,
+          "provider_excludes": [
+            "AWS_SENTINEL_2_L2A_COGS"
+          ],
+          "query": {
+            "sort_by": "CLOUD_COVER",
+            "sort_direction": "ASC"
+          },
+          "timeout": "0:0:10"
+        },
+        "query_config": {
+          "max_matches": 12,
+          "min_matches": 1,
+          "period_duration": "30d",
+          "space_mode": "MOSAIC"
+        },
+        "time_offset": "0d"
+      },
+      "type": "raster"
+    }
+  }
+}

--- a/data/large_scale_embeddings/s2_s1.json
+++ b/data/large_scale_embeddings/s2_s1.json
@@ -4,6 +4,14 @@
       "band_sets": [
         {
           "dtype": "int8",
+          "format": {
+            "class_path": "rslearn.utils.raster_format.GeotiffRasterFormat",
+            "init_args": {
+              "geotiff_options": {
+                "compress": "none"
+              }
+            }
+          },
           "num_bands": 128
         }
       ],
@@ -23,9 +31,7 @@
         "class_path": "olmoearth_run.runner.tools.rslearn_data_sources.olmoearth_datasets.sentinel1_rtc.Sentinel1RTC",
         "duration": "365d",
         "ingest": false,
-        "init_args": {
-          "timeout": "0:0:10"
-        },
+        "init_args": {},
         "query_config": {
           "max_matches": 12,
           "min_matches": 1,
@@ -69,8 +75,7 @@
           "query": {
             "sort_by": "CLOUD_COVER",
             "sort_direction": "ASC"
-          },
-          "timeout": "0:0:10"
+          }
         },
         "query_config": {
           "max_matches": 12,

--- a/data/large_scale_embeddings/s2_s1.yaml
+++ b/data/large_scale_embeddings/s2_s1.yaml
@@ -11,6 +11,10 @@ model:
               # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
               patch_size: 1
               embedding_size: 128
+              # Output the 128-dim spatial register bottleneck latents (one per
+              # patch in dynamic-grid mode) rather than the 768-dim encoder patch
+              # tokens.
+              use_register_bottleneck_output: true
               # Normalize inputs inside the encoder. Sentinel-1 is converted to
               # decibels by the Sentinel1ToDecibels transform below first, since the
               # normalization stats expect dB.
@@ -21,6 +25,10 @@ model:
               # samples with differing numbers of mosaics so they can be batched
               # together.
               use_legacy_timestamps: false
+              # Compile the encoder transformer blocks (the register bottleneck
+              # stays eager). Inference uses fixed 16x16 crops so recompilations
+              # are limited to the few distinct batch/timestep shapes.
+              compile_model: true
         decoder:
           # L2-normalizes each pixel's embedding and quantizes it to int8 using the
           # AlphaEarth-style power scheme (-128 is reserved for nodata).
@@ -57,7 +65,7 @@ data:
       class_path: rslearn.train.tasks.embedding.EmbeddingTask
     # Crops are tiny (16x16) so a large batch size is needed for throughput. Tune
     # per GPU along with num_workers.
-    batch_size: 64
+    batch_size: 256
     num_workers: 16
     default_config:
       # The model must operate on 16x16 crops; anything bigger fails with the 12
@@ -76,7 +84,7 @@ data:
       load_all_crops: true
       # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
       # RasterMerger below trims half the overlap from each crop when merging.
-      overlap_pixels: 8
+      overlap_pixels: 4
       skip_targets: true
 trainer:
   callbacks:
@@ -89,4 +97,4 @@ trainer:
           class_path: rslearn.train.prediction_writer.RasterMerger
           init_args:
             downsample_factor: 1
-            overlap_pixels: 8
+            overlap_pixels: 4

--- a/data/large_scale_embeddings/s2_s1.yaml
+++ b/data/large_scale_embeddings/s2_s1.yaml
@@ -1,0 +1,92 @@
+model:
+  class_path: rslearn.train.lightning_module.RslearnLightningModule
+  init_args:
+    model:
+      class_path: rslearn.models.singletask.SingleTaskModel
+      init_args:
+        encoder:
+          - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
+            init_args:
+              checkpoint_path: /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+              # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
+              patch_size: 1
+              embedding_size: 128
+              # Normalize inputs inside the encoder. Sentinel-1 is converted to
+              # decibels by the Sentinel1ToDecibels transform below first, since the
+              # normalization stats expect dB.
+              normalize: true
+              autocast_dtype: bfloat16
+              # Use the actual mosaic timestamps (from the materialized layer
+              # metadata) rather than dummy monthly timestamps. This also pads
+              # samples with differing numbers of mosaics so they can be batched
+              # together.
+              use_legacy_timestamps: false
+        decoder:
+          # L2-normalizes each pixel's embedding and quantizes it to int8 using the
+          # AlphaEarth-style power scheme (-128 is reserved for nodata).
+          - class_path: rslp.large_scale_embeddings.model.QuantizedEmbeddingHead
+            init_args:
+              l2_normalize: true
+data:
+  class_path: rslearn.train.data_module.RslearnDataModule
+  init_args:
+    # Overridden by the prediction pipeline via --data.init_args.path.
+    path: placeholder
+    inputs:
+      sentinel2_l2a:
+        data_type: "raster"
+        layers: ["sentinel2_l2a"]
+        bands: ["B02", "B03", "B04", "B08", "B05", "B06", "B07", "B8A", "B11", "B12", "B01", "B09"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+        load_all_item_groups: true
+      sentinel1:
+        data_type: "raster"
+        layers: ["sentinel1"]
+        bands: ["vv", "vh"]
+        passthrough: true
+        dtype: FLOAT32
+        load_all_layers: true
+        load_all_item_groups: true
+        # Sentinel-1 is best-effort: windows missing it are still processed with
+        # Sentinel-2 only.
+        required: false
+    task:
+      # Inference-only task: no targets/loss; writes the head's int8 output.
+      class_path: rslearn.train.tasks.embedding.EmbeddingTask
+    # Crops are tiny (16x16) so a large batch size is needed for throughput. Tune
+    # per GPU along with num_workers.
+    batch_size: 64
+    num_workers: 16
+    default_config:
+      # The model must operate on 16x16 crops; anything bigger fails with the 12
+      # monthly inputs at patch_size=1 due to GPU memory constraints.
+      crop_size: 16
+      transforms:
+        # The Sentinel-1 RTC source delivers linear intensities; convert to dB as
+        # expected by the OlmoEarth normalization stats.
+        - class_path: rslearn.train.transforms.sentinel1.Sentinel1ToDecibels
+          init_args:
+            selectors: ["sentinel1"]
+            # Sentinel-1 is optional (required: false above), so skip samples
+            # where it is missing.
+            skip_missing: true
+    predict_config:
+      load_all_crops: true
+      # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
+      # RasterMerger below trims half the overlap from each crop when merging.
+      overlap_pixels: 8
+      skip_targets: true
+trainer:
+  callbacks:
+    # Writes the int8 128-band embedding raster to the "output" layer.
+    - class_path: rslearn.train.prediction_writer.RslearnWriter
+      init_args:
+        output_layer: output
+        selector: []
+        merger:
+          class_path: rslearn.train.prediction_writer.RasterMerger
+          init_args:
+            downsample_factor: 1
+            overlap_pixels: 8

--- a/data/large_scale_embeddings/s2_s1.yaml
+++ b/data/large_scale_embeddings/s2_s1.yaml
@@ -7,7 +7,9 @@ model:
         encoder:
           - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
             init_args:
-              checkpoint_path: /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+              # The OlmoEarth checkpoint to compute embeddings with, e.g.
+              # /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+              checkpoint_path: ${CHECKPOINT_PATH}
               # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
               patch_size: 1
               embedding_size: 128
@@ -25,10 +27,11 @@ model:
               # samples with differing numbers of mosaics so they can be batched
               # together.
               use_legacy_timestamps: false
-              # Compile the encoder transformer blocks (the register bottleneck
-              # stays eager). Inference uses fixed 16x16 crops so recompilations
-              # are limited to the few distinct batch/timestep shapes.
-              compile_model: true
+              # Whether to compile the encoder transformer blocks (the register
+              # bottleneck stays eager). Inference uses fixed WINDOW_SIZE crops so
+              # recompilations are limited to the few distinct batch/timestep
+              # shapes.
+              compile_model: ${COMPILE_MODEL}
         decoder:
           # L2-normalizes each pixel's embedding and quantizes it to int8 using the
           # AlphaEarth-style power scheme (-128 is reserved for nodata).
@@ -63,14 +66,14 @@ data:
     task:
       # Inference-only task: no targets/loss; writes the head's int8 output.
       class_path: rslearn.train.tasks.embedding.EmbeddingTask
-    # Crops are tiny (16x16) so a large batch size is needed for throughput. Tune
-    # per GPU along with num_workers.
+    # Crops are tiny (e.g. 16x16) so a large batch size is needed for throughput.
+    # Tune per GPU along with num_workers.
     batch_size: 256
     num_workers: 16
     default_config:
-      # The model must operate on 16x16 crops; anything bigger fails with the 12
-      # monthly inputs at patch_size=1 due to GPU memory constraints.
-      crop_size: 16
+      # The size of the crops the model operates on, e.g. 16 (much bigger fails
+      # with the 12 monthly inputs at patch_size=1 due to GPU memory constraints).
+      crop_size: ${WINDOW_SIZE}
       transforms:
         # The Sentinel-1 RTC source delivers linear intensities; convert to dB as
         # expected by the OlmoEarth normalization stats.
@@ -84,7 +87,8 @@ data:
       load_all_crops: true
       # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
       # RasterMerger below trims half the overlap from each crop when merging.
-      overlap_pixels: 4
+      # Must match the RasterMerger overlap_pixels.
+      overlap_pixels: ${OVERLAP_SIZE}
       skip_targets: true
 trainer:
   callbacks:
@@ -97,4 +101,5 @@ trainer:
           class_path: rslearn.train.prediction_writer.RasterMerger
           init_args:
             downsample_factor: 1
-            overlap_pixels: 4
+            # Must match the predict_config overlap_pixels.
+            overlap_pixels: ${OVERLAP_SIZE}

--- a/data/large_scale_embeddings/s2_s1.yaml
+++ b/data/large_scale_embeddings/s2_s1.yaml
@@ -8,9 +8,12 @@ model:
           - class_path: rslearn.models.olmoearth_pretrain.model.OlmoEarth
             init_args:
               # The OlmoEarth checkpoint to compute embeddings with, e.g.
-              # /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
-              checkpoint_path: ${CHECKPOINT_PATH}
+              # /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000.
+              # This placeholder is always overridden by the prediction pipeline
+              # (--checkpoint_path).
+              checkpoint_path: /path/to/checkpoint_dir
               # patch_size 1 yields one 128-dimensional embedding per 10 m pixel.
+              # Overridden by the prediction pipeline (--patch_size).
               patch_size: 1
               embedding_size: 128
               # Output the 128-dim spatial register bottleneck latents (one per
@@ -28,10 +31,10 @@ model:
               # together.
               use_legacy_timestamps: false
               # Whether to compile the encoder transformer blocks (the register
-              # bottleneck stays eager). Inference uses fixed WINDOW_SIZE crops so
+              # bottleneck stays eager). Inference uses fixed-size crops so
               # recompilations are limited to the few distinct batch/timestep
-              # shapes.
-              compile_model: ${COMPILE_MODEL}
+              # shapes. Overridden by the prediction pipeline (--compile_model).
+              compile_model: true
         decoder:
           # L2-normalizes each pixel's embedding and quantizes it to int8 using the
           # AlphaEarth-style power scheme (-128 is reserved for nodata).
@@ -71,9 +74,10 @@ data:
     batch_size: 256
     num_workers: 16
     default_config:
-      # The size of the crops the model operates on, e.g. 16 (much bigger fails
-      # with the 12 monthly inputs at patch_size=1 due to GPU memory constraints).
-      crop_size: ${WINDOW_SIZE}
+      # The size of the crops the model operates on (much bigger fails with the 12
+      # monthly inputs at patch_size=1 due to GPU memory constraints). Overridden
+      # by the prediction pipeline (--window_size).
+      crop_size: 16
       transforms:
         # The Sentinel-1 RTC source delivers linear intensities; convert to dB as
         # expected by the OlmoEarth normalization stats.
@@ -87,8 +91,9 @@ data:
       load_all_crops: true
       # Overlap adjacent crops to mitigate embedding seams at crop boundaries; the
       # RasterMerger below trims half the overlap from each crop when merging.
-      # Must match the RasterMerger overlap_pixels.
-      overlap_pixels: ${OVERLAP_SIZE}
+      # Must match the RasterMerger overlap_pixels (times patch_size). Overridden
+      # by the prediction pipeline (--overlap_size).
+      overlap_pixels: 4
       skip_targets: true
 trainer:
   callbacks:
@@ -100,6 +105,10 @@ trainer:
         merger:
           class_path: rslearn.train.prediction_writer.RasterMerger
           init_args:
+            # Must match the encoder patch_size. Overridden by the prediction
+            # pipeline (--patch_size).
             downsample_factor: 1
-            # Must match the predict_config overlap_pixels.
-            overlap_pixels: ${OVERLAP_SIZE}
+            # Must be the predict_config overlap_pixels divided by the encoder
+            # patch_size (the merger operates at the output resolution).
+            # Overridden by the prediction pipeline.
+            overlap_pixels: 4

--- a/olmoearth_pretrain.Dockerfile
+++ b/olmoearth_pretrain.Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime
+FROM pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
 
 RUN apt update
 RUN apt install -y libpq-dev ffmpeg libsm6 libxext6 git wget
@@ -13,15 +13,16 @@ COPY requirements.txt /opt/rslearn_projects/requirements.txt
 COPY requirements-extra.txt /opt/rslearn_projects/requirements-extra.txt
 COPY requirements-olmocore.txt /opt/rslearn_projects/requirements-olmocore.txt
 # Using cache mount here avoids needing to re-download dependencies for later builds if the version didn't change.
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install --system /opt/rslearn[extra] /opt/olmoearth_pretrain -r /opt/rslearn_projects/requirements.txt -r /opt/rslearn_projects/requirements-extra.txt -r /opt/rslearn_projects/requirements-olmocore.txt
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install --system --break-system-packages /opt/rslearn[extra] /opt/olmoearth_pretrain -r /opt/rslearn_projects/requirements.txt -r /opt/rslearn_projects/requirements-extra.txt -r /opt/rslearn_projects/requirements-olmocore.txt
 
 # Now copy the source code and install for real.
 # If we don't change any dependencies, then only these steps need to be repeated
 # (fast and means the new layers have small size).
 COPY ./docker_build/rslearn /opt/rslearn
 COPY ./docker_build/olmoearth_pretrain /opt/olmoearth_pretrain
+COPY ./docker_build/olmoearth_run /opt/olmoearth_run
 COPY . /opt/rslearn_projects/
 
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install --system /opt/rslearn[extra] /opt/olmoearth_pretrain /opt/rslearn_projects[extra]
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install --system --break-system-packages /opt/rslearn[extra] /opt/olmoearth_pretrain /opt/rslearn_projects[extra] /opt/olmoearth_run[runner]
 
 WORKDIR /opt/rslearn_projects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+gcsfs>=2025.2.0
 global-land-mask>=1.0.0
+# jsonargparse 4.50 dropped the cfg_str positional that rslearn's parser override needs.
+jsonargparse[signatures]>=4.39.0,<4.50
 prometheus-client>=0.21.1
 python-dotenv>=1.0
 PyYAML>=6
 rslearn>=0.1.9
 s3fs>=2025.2.0
 wandb>=0.21
+zarr>=3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+global-land-mask>=1.0.0
 prometheus-client>=0.21.1
 python-dotenv>=1.0
 PyYAML>=6

--- a/rslp/large_scale_embeddings/README.md
+++ b/rslp/large_scale_embeddings/README.md
@@ -19,8 +19,19 @@ and so must be written to different output paths:
 
 The configuration files are in `data/large_scale_embeddings/`: `s2.json`/`s2_s1.json`
 are the rslearn dataset configs (imagery comes from the OlmoEarth Datasets sources)
-and `s2.yaml`/`s2_s1.yaml` are the model configs (which reference the OlmoEarth
-checkpoint on WEKA).
+and `s2.yaml`/`s2_s1.yaml` are the model configs.
+
+The model configs require several environment variables (substituted via `${VAR}`
+before parsing; there are no defaults, so all of them must be set):
+
+- `CHECKPOINT_PATH`: the OlmoEarth checkpoint to compute embeddings with, e.g.
+  `/weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000`.
+- `WINDOW_SIZE`: the size of the crops the model operates on, e.g. `16` (much
+  bigger fails with the 12 monthly inputs at patch_size=1 due to GPU memory
+  constraints).
+- `OVERLAP_SIZE`: overlap in pixels between adjacent crops, to mitigate embedding
+  seams at crop boundaries, e.g. `4`.
+- `COMPILE_MODEL`: whether to compile the encoder transformer blocks, e.g. `true`.
 
 
 How It Works
@@ -55,6 +66,10 @@ Running One Tile Locally
 This requires a GPU and access to the OlmoEarth checkpoint (e.g. run on a machine with
 WEKA mounted). From the rslearn_projects root:
 
+    export CHECKPOINT_PATH=/weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+    export WINDOW_SIZE=16
+    export OVERLAP_SIZE=4
+    export COMPILE_MODEL=true
     python -m rslp.main large_scale_embeddings predict \
         --inputs S2 \
         --projection_json '{"crs": "EPSG:32610", "x_resolution": 10, "y_resolution": -10}' \
@@ -102,7 +117,8 @@ Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
 3. Launch workers on Beaker (WEKA must be mounted for the checkpoint). The
    OlmoEarth Datasets data source needs `OEDATASETS_API_URL` (plain env var) and
    `DATASETS_API_TOKEN` (bearer token, read from the `LCC_DATASETS_API_TOKEN`
-   Beaker secret which must exist in the `ai2/earth-systems` workspace):
+   Beaker secret which must exist in the `ai2/earth-systems` workspace), and the
+   model config env vars described above are passed the same way:
 
         python -m rslp.main common launch \
             --image_name favyen/rslpomp20260721b \
@@ -112,7 +128,7 @@ Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
             --priority urgent \
             --cluster '["ai2/jupiter","ai2/ceres"]' \
             --weka_mounts+='{"bucket_name": "dfive-default", "mount_path": "/weka/dfive-default"}' \
-            --extra_env_vars '{"OEDATASETS_API_URL": "https://datasets.olmoearth.allenai.org"}' \
+            --extra_env_vars '{"OEDATASETS_API_URL": "https://datasets.olmoearth.allenai.org", "CHECKPOINT_PATH": "/weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000", "WINDOW_SIZE": "16", "OVERLAP_SIZE": "4", "COMPILE_MODEL": "true"}' \
             --extra_env_secrets '{"DATASETS_API_TOKEN": "LCC_DATASETS_API_TOKEN"}'
 
 Progress can be monitored by counting marker files in `completed_path`. To retry

--- a/rslp/large_scale_embeddings/README.md
+++ b/rslp/large_scale_embeddings/README.md
@@ -1,0 +1,139 @@
+Large-Scale Embeddings
+======================
+
+This project computes OlmoEarth embeddings over large areas (up to global scale). The
+embeddings are:
+
+- 10 m/pixel, in the appropriate UTM projection for each location.
+- 128-dimensional, L2-normalized, and quantized to int8 (see Quantization below).
+- Computed from one year of input imagery starting at a user-provided reference
+  timestamp.
+
+There are two input variants (`EmbeddingInputs`), which produce different embeddings
+and so must be written to different output paths:
+
+- `S2`: twelve monthly Sentinel-2 L2A mosaics.
+- `S2_S1`: the above, plus twelve monthly Sentinel-1 RTC mosaics (converted from
+  linear intensities to dB). Sentinel-1 is best-effort: where it is unavailable, the
+  embeddings are computed from Sentinel-2 alone. Sentinel-2 coverage is required.
+
+The configuration files are in `data/large_scale_embeddings/`: `s2.json`/`s2_s1.json`
+are the rslearn dataset configs (imagery comes from the OlmoEarth Datasets sources)
+and `s2.yaml`/`s2_s1.yaml` are the model configs (which reference the OlmoEarth
+checkpoint on WEKA).
+
+
+How It Works
+------------
+
+The world is divided into 32768x32768-pixel tiles in each UTM zone, and each tile is
+one unit of work (one queue job). The prediction pipeline for a tile creates
+2048x2048-pixel windows in a scratch rslearn dataset, materializes the input mosaics,
+runs the model, and uploads one GeoTIFF per window to `out_path`, named
+`{crs}_{x}_{y}.tif` (x/y are the pixel offsets of the window in the UTM projection at
+10 m/pixel). GeoTIFFs are ZSTD-compressed and tiled with 512x512 blocks, with nodata
+value -128.
+
+To limit duplicated work where UTM zones overlap, tiles and windows are skipped unless
+they intersect their zone's canonical 6-degree wedge (see `tiling.py`). Windows that
+are entirely ocean (per `global_land_mask`) or too close to 0/180 longitude (where
+mosaics are unreliable) are also skipped.
+
+When a tile finishes, a marker file `{crs}_{x}_{y}.json` is written to
+`completed_path` recording the tile's projection, bounds, and time range, plus which
+windows were written and which were skipped (`written`, `skipped_no_data` for windows
+without Sentinel-2 coverage, `skipped_longitude`, and `num_filtered_crops` for
+wedge/ocean-filtered windows). Tiles with existing markers are excluded when writing
+jobs and skipped by the prediction pipeline, so the pipeline is idempotent and jobs
+can safely be re-enqueued to retry failures.
+
+
+Running One Tile Locally
+------------------------
+
+This requires a GPU and access to the OlmoEarth checkpoint (e.g. run on a machine with
+WEKA mounted). From the rslearn_projects root:
+
+    python -m rslp.main large_scale_embeddings predict \
+        --inputs S2 \
+        --projection_json '{"crs": "EPSG:32610", "x_resolution": 10, "y_resolution": -10}' \
+        --bounds '[32768, -557056, 65536, -524288]' \
+        --time_range '["2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+00:00"]' \
+        --out_path gs://BUCKET/embeddings/s2/2024/ \
+        --completed_path gs://BUCKET/embeddings/s2/2024_completed/
+
+`bounds` can be any box whose extents are multiples of 2048 (it does not have to be a
+32768x32768 tile). `time_range` is `(T, T)` where T is the reference timestamp; the
+dataset config derives the twelve monthly mosaics over the year following T. By
+default the scratch rslearn dataset is placed in a temporary directory and deleted;
+pass `--scratch_path /path/to/scratch/` to keep it for debugging.
+
+
+Running at Scale
+----------------
+
+Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
+
+1. Build and push a Beaker image containing rslearn_projects (with the
+   `global-land-mask` dependency included).
+
+2. Write jobs to a Beaker queue, one per uncompleted tile:
+
+        python -m rslp.main large_scale_embeddings write_jobs \
+            --inputs S2 \
+            --timestamp '2025-01-01T00:00:00+00:00' \
+            --out_path gs://ai2-olmoearth-embeddings-us-central1/large_scale_embeddings/20270721/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/ps1_ws16_s2/2025/ \
+            --completed_path gs://ai2-olmoearth-embeddings-us-central1/large_scale_embeddings/20270721/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/ps1_ws16_s2/2025_completed/ \
+            --queue_name favyen/rslp-large-scale-embeddings-queue
+
+   Without additional arguments this enumerates all land tiles globally (~8,700).
+   Options to limit the extent:
+
+   - `--epsg_code 32610`: only one UTM zone.
+   - `--wgs84_bounds '[-125.0, 45.0, -116.0, 49.0]'`: only tiles intersecting these
+     WGS84 bounds.
+   - `--geojson_fname data/large_scale_embeddings/initial_regions.geojson`: only
+     tiles intersecting a feature in the given WGS84 GeoJSON file (the included
+     `initial_regions.geojson` covers Washington, Montana, Ukraine, Thailand, and
+     points in Greenland and coastal Antarctica; 88 tiles).
+   - `--count 10`: randomly sample this many tiles.
+
+3. Launch workers on Beaker (WEKA must be mounted for the checkpoint). The
+   OlmoEarth Datasets data source needs `OEDATASETS_API_URL` (plain env var) and
+   `DATASETS_API_TOKEN` (bearer token, read from the `LCC_DATASETS_API_TOKEN`
+   Beaker secret which must exist in the `ai2/earth-systems` workspace):
+
+        python -m rslp.main common launch \
+            --image_name favyen/rslpomp20260721b \
+            --queue_name favyen/rslp-large-scale-embeddings-queue \
+            --num_workers 4 \
+            --gpus 1 \
+            --priority urgent \
+            --cluster '["ai2/jupiter","ai2/ceres"]' \
+            --weka_mounts+='{"bucket_name": "dfive-default", "mount_path": "/weka/dfive-default"}' \
+            --extra_env_vars '{"OEDATASETS_API_URL": "https://datasets.olmoearth.allenai.org"}' \
+            --extra_env_secrets '{"DATASETS_API_TOKEN": "LCC_DATASETS_API_TOKEN"}'
+
+Progress can be monitored by counting marker files in `completed_path`. To retry
+failed tiles, simply run `write_jobs` again: completed tiles are excluded.
+
+Remember to use different `out_path`/`completed_path` per input variant and per
+reference timestamp.
+
+
+Quantization
+------------
+
+Embeddings are L2-normalized and then quantized following the AlphaEarth scheme (see
+`model.py`): `quantized = round(sign(x) * |x|^0.5 * 127.5)` clipped to [-127, 127],
+with -128 reserved for nodata. To recover approximate float embeddings:
+
+```python
+import numpy as np
+
+def dequantize(v: np.ndarray) -> np.ndarray:
+    x = v.astype(np.float32) / 127.5
+    return np.sign(x) * np.abs(x) ** 2.0
+```
+
+Pixels where all Sentinel-2 mosaics are empty are set to -128 in all bands.

--- a/rslp/large_scale_embeddings/README.md
+++ b/rslp/large_scale_embeddings/README.md
@@ -31,7 +31,8 @@ one unit of work (one queue job). The prediction pipeline for a tile creates
 2048x2048-pixel windows in a scratch rslearn dataset, materializes the input mosaics,
 runs the model, and uploads one GeoTIFF per window to `out_path`, named
 `{crs}_{x}_{y}.tif` (x/y are the pixel offsets of the window in the UTM projection at
-10 m/pixel). GeoTIFFs are ZSTD-compressed and tiled with 512x512 blocks, with nodata
+10 m/pixel). GeoTIFFs are uncompressed (the int8 embeddings are high-entropy, so
+compression only slows down writes) and tiled with 512x512 blocks, with nodata
 value -128.
 
 To limit duplicated work where UTM zones overlap, tiles and windows are skipped unless

--- a/rslp/large_scale_embeddings/README.md
+++ b/rslp/large_scale_embeddings/README.md
@@ -4,7 +4,8 @@ Large-Scale Embeddings
 This project computes OlmoEarth embeddings over large areas (up to global scale). The
 embeddings are:
 
-- 10 m/pixel, in the appropriate UTM projection for each location.
+- 10 m/pixel (at the default `--patch_size 1`; in general patch_size x 10 m/pixel),
+  in the appropriate UTM projection for each location.
 - 128-dimensional, L2-normalized, and quantized to int8 (see Quantization below).
 - Computed from one year of input imagery starting at a user-provided reference
   timestamp.
@@ -21,17 +22,27 @@ The configuration files are in `data/large_scale_embeddings/`: `s2.json`/`s2_s1.
 are the rslearn dataset configs (imagery comes from the OlmoEarth Datasets sources)
 and `s2.yaml`/`s2_s1.yaml` are the model configs.
 
-The model configs require several environment variables (substituted via `${VAR}`
-before parsing; there are no defaults, so all of them must be set):
+The model settings are provided as arguments to `write_jobs`/`predict` and override
+the defaults in the model configs (they are recorded in each queue job, so workers
+can process jobs with differing settings):
 
-- `CHECKPOINT_PATH`: the OlmoEarth checkpoint to compute embeddings with, e.g.
+- `--checkpoint_path` (required): the OlmoEarth checkpoint to compute embeddings
+  with, e.g.
   `/weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000`.
-- `WINDOW_SIZE`: the size of the crops the model operates on, e.g. `16` (much
+- `--patch_size` (default `1`): the encoder patch size, yielding one embedding per
+  patch_size x patch_size pixels; the output rasters are at 1/patch_size of the
+  10 m/pixel window resolution.
+- `--window_size` (default `16`): the size of the crops the model operates on (much
   bigger fails with the 12 monthly inputs at patch_size=1 due to GPU memory
   constraints).
-- `OVERLAP_SIZE`: overlap in pixels between adjacent crops, to mitigate embedding
-  seams at crop boundaries, e.g. `4`.
-- `COMPILE_MODEL`: whether to compile the encoder transformer blocks, e.g. `true`.
+- `--overlap_size` (default `4`): overlap in pixels between adjacent crops, to
+  mitigate embedding seams at crop boundaries. Must be a multiple of patch_size.
+- `--compile_model` (default `true`): whether to compile the encoder transformer
+  blocks.
+
+Note that the checkpoint and the patch/window/overlap sizes all affect the resulting
+embeddings, so each combination must use its own `out_path`/`completed_path` (like
+the input variants).
 
 
 How It Works
@@ -42,6 +53,7 @@ one unit of work (one queue job). The prediction pipeline for a tile creates
 2048x2048-pixel windows in a scratch rslearn dataset, materializes the input mosaics,
 runs the model, and uploads one GeoTIFF per window to `out_path`, named
 `{crs}_{x}_{y}.tif` (x/y are the pixel offsets of the window in the UTM projection at
+10 m/pixel, regardless of patch_size; the GeoTIFF itself is at patch_size x
 10 m/pixel). GeoTIFFs are uncompressed (the int8 embeddings are high-entropy, so
 compression only slows down writes) and tiled with 512x512 blocks, with nodata
 value -128.
@@ -66,17 +78,14 @@ Running One Tile Locally
 This requires a GPU and access to the OlmoEarth checkpoint (e.g. run on a machine with
 WEKA mounted). From the rslearn_projects root:
 
-    export CHECKPOINT_PATH=/weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
-    export WINDOW_SIZE=16
-    export OVERLAP_SIZE=4
-    export COMPILE_MODEL=true
     python -m rslp.main large_scale_embeddings predict \
         --inputs S2 \
         --projection_json '{"crs": "EPSG:32610", "x_resolution": 10, "y_resolution": -10}' \
         --bounds '[32768, -557056, 65536, -524288]' \
         --time_range '["2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+00:00"]' \
         --out_path gs://BUCKET/embeddings/s2/2024/ \
-        --completed_path gs://BUCKET/embeddings/s2/2024_completed/
+        --completed_path gs://BUCKET/embeddings/s2/2024_completed/ \
+        --checkpoint_path /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
 
 `bounds` can be any box whose extents are multiples of 2048 (it does not have to be a
 32768x32768 tile). `time_range` is `(T, T)` where T is the reference timestamp; the
@@ -100,8 +109,11 @@ Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
             --timestamp '2025-01-01T00:00:00+00:00' \
             --out_path gs://ai2-olmoearth-embeddings-us-central1/large_scale_embeddings/20270721/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/ps1_ws16_s2/2025/ \
             --completed_path gs://ai2-olmoearth-embeddings-us-central1/large_scale_embeddings/20270721/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/ps1_ws16_s2/2025_completed/ \
+            --checkpoint_path /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000 \
             --queue_name favyen/rslp-large-scale-embeddings-queue
 
+   The model settings (`--checkpoint_path`, `--patch_size`, `--window_size`,
+   `--overlap_size`, `--compile_model`; see above) are recorded in each job.
    Without additional arguments this enumerates all land tiles globally (~8,700).
    Options to limit the extent:
 
@@ -117,8 +129,7 @@ Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
 3. Launch workers on Beaker (WEKA must be mounted for the checkpoint). The
    OlmoEarth Datasets data source needs `OEDATASETS_API_URL` (plain env var) and
    `DATASETS_API_TOKEN` (bearer token, read from the `LCC_DATASETS_API_TOKEN`
-   Beaker secret which must exist in the `ai2/earth-systems` workspace), and the
-   model config env vars described above are passed the same way:
+   Beaker secret which must exist in the `ai2/earth-systems` workspace):
 
         python -m rslp.main common launch \
             --image_name favyen/rslpomp20260721b \
@@ -128,14 +139,15 @@ Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
             --priority urgent \
             --cluster '["ai2/jupiter","ai2/ceres"]' \
             --weka_mounts+='{"bucket_name": "dfive-default", "mount_path": "/weka/dfive-default"}' \
-            --extra_env_vars '{"OEDATASETS_API_URL": "https://datasets.olmoearth.allenai.org", "CHECKPOINT_PATH": "/weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000", "WINDOW_SIZE": "16", "OVERLAP_SIZE": "4", "COMPILE_MODEL": "true"}' \
-            --extra_env_secrets '{"DATASETS_API_TOKEN": "LCC_DATASETS_API_TOKEN"}'
+            --extra_env_vars '{"OEDATASETS_API_URL": "https://datasets.olmoearth.allenai.org"}' \
+            --extra_env_secrets '{"DATASETS_API_TOKEN": "LCC_DATASETS_API_TOKEN"}' \
+            --shared_memory 256GiB
 
 Progress can be monitored by counting marker files in `completed_path`. To retry
 failed tiles, simply run `write_jobs` again: completed tiles are excluded.
 
-Remember to use different `out_path`/`completed_path` per input variant and per
-reference timestamp.
+Remember to use different `out_path`/`completed_path` per input variant, model
+settings (checkpoint and patch/window/overlap sizes), and reference timestamp.
 
 
 Quantization

--- a/rslp/large_scale_embeddings/README.md
+++ b/rslp/large_scale_embeddings/README.md
@@ -1,17 +1,18 @@
 Large-Scale Embeddings
 ======================
 
-This project computes OlmoEarth embeddings over large areas (up to global scale). The
-embeddings are:
+This project computes OlmoEarth embeddings over large areas (up to global scale) and
+writes them to a GeoZarr store following the geoemb embeddings-zarr-convention
+(https://github.com/geo-embeddings/embeddings-zarr-convention). The embeddings are:
 
 - 10 m/pixel (at the default `--patch_size 1`; in general patch_size x 10 m/pixel),
   in the appropriate UTM projection for each location.
 - 128-dimensional, L2-normalized, and quantized to int8 (see Quantization below).
 - Computed from one year of input imagery starting at a user-provided reference
-  timestamp.
+  timestamp; multiple reference years form the store's time axis.
 
 There are two input variants (`EmbeddingInputs`), which produce different embeddings
-and so must be written to different output paths:
+and so must be written to different stores:
 
 - `S2`: twelve monthly Sentinel-2 L2A mosaics.
 - `S2_S1`: the above, plus twelve monthly Sentinel-1 RTC mosaics (converted from
@@ -41,57 +42,95 @@ can process jobs with differing settings):
   blocks.
 
 Note that the checkpoint and the patch/window/overlap sizes all affect the resulting
-embeddings, so each combination must use its own `out_path`/`completed_path` (like
-the input variants).
+embeddings, so each combination must use its own `store`/`completed_path` (like the
+input variants).
+
+
+Output Store
+------------
+
+The store is a Zarr v3 group using the geoemb `utm_zones` spatial layout: one group
+per UTM zone number named `utm{NN}` (01-60). Each zone is stored in its northern CRS
+(EPSG:326NN) with a continuous northing axis that goes negative south of the equator,
+so a single group covers both hemispheres (matching the reference GeoTessera
+implementation of the convention). Each zone group holds:
+
+- an `embeddings` array with dimensions `(time, band, y, x)`: `band` is the 128-dim
+  embedding vector, `time` is the annual reference years. It is int8, sharded so that
+  one shard equals one 2048x2048 prediction window (with 256x256 inner chunks),
+  zstd-compressed, with fill/nodata value -128.
+- `time`, `x`, and `y` coordinate arrays.
+- `proj:` and `spatial:` attributes (CRS and affine transform) and the geoemb
+  provenance attributes (model, source data, quantization, etc.).
+
+Because the array is sharded and sparse, only shards that intersect land are written;
+ocean and unprocessed regions read back as the -128 nodata value.
 
 
 How It Works
 ------------
 
-The world is divided into 32768x32768-pixel tiles in each UTM zone, and each tile is
-one unit of work (one queue job). The prediction pipeline for a tile creates
-2048x2048-pixel windows in a scratch rslearn dataset, materializes the input mosaics,
-runs the model, and uploads one GeoTIFF per window to `out_path`, named
-`{crs}_{x}_{y}.tif` (x/y are the pixel offsets of the window in the UTM projection at
-10 m/pixel, regardless of patch_size; the GeoTIFF itself is at patch_size x
-10 m/pixel). GeoTIFFs are uncompressed (the int8 embeddings are high-entropy, so
-compression only slows down writes) and tiled with 512x512 blocks, with nodata
-value -128.
+Each UTM zone number (1-60) is processed once in its northern CRS. The zone is divided
+into 32768x32768-pixel tiles, and each tile is one unit of work (one queue job). The
+prediction pipeline for a tile creates 2048x2048-pixel windows in a scratch rslearn
+dataset, materializes the input mosaics, runs the model, and writes each window's int8
+embeddings (at 1/patch_size of the 10 m/pixel input resolution) into the store's zone
+array at the window's `(time, y, x)` region. Windows are aligned to the store's shard
+grid, so each window writes exactly one shard and concurrent workers never touch the
+same shard.
 
 To limit duplicated work where UTM zones overlap, tiles and windows are skipped unless
-they intersect their zone's canonical 6-degree wedge (see `tiling.py`). Windows that
-are entirely ocean (per `global_land_mask`) or too close to 0/180 longitude (where
-mosaics are unreliable) are also skipped.
+they intersect their zone's canonical 6-degree longitude wedge, which spans the full
+UTM latitude range (see `tiling.py`). Windows that are entirely ocean (per
+`global_land_mask`) or too close to 0/180 longitude (where mosaics are unreliable) are
+also skipped.
 
 When a tile finishes, a marker file `{crs}_{x}_{y}.json` is written to
-`completed_path` recording the tile's projection, bounds, and time range, plus which
-windows were written and which were skipped (`written`, `skipped_no_data` for windows
-without Sentinel-2 coverage, `skipped_longitude`, and `num_filtered_crops` for
-wedge/ocean-filtered windows). Tiles with existing markers are excluded when writing
-jobs and skipped by the prediction pipeline, so the pipeline is idempotent and jobs
-can safely be re-enqueued to retry failures.
+`completed_path` recording the tile's projection, bounds, time range, time index, and
+which windows were written and which were skipped (`written`, `skipped_no_data` for
+windows without Sentinel-2 coverage, `skipped_longitude`, and `num_filtered_crops`
+for wedge/ocean-filtered windows). Tiles with existing markers are excluded when
+writing jobs and skipped by the prediction pipeline, so the pipeline is idempotent and
+jobs can safely be re-enqueued to retry failures.
+
+The store must be created once with `init_store` before any prediction jobs run.
+`init_store` writes all group metadata (root, zone groups, arrays, coordinates), so
+prediction workers only ever write data regions and never mutate metadata, which
+keeps concurrent writes safe.
 
 
 Running One Tile Locally
 ------------------------
 
 This requires a GPU and access to the OlmoEarth checkpoint (e.g. run on a machine with
-WEKA mounted). From the rslearn_projects root:
+WEKA mounted). From the rslearn_projects root, first create the store, then run a
+tile:
+
+    python -m rslp.main large_scale_embeddings init_store \
+        --store_path gs://BUCKET/embeddings/s2.zarr \
+        --years '[2024]' \
+        --model_url https://huggingface.co/allenai/OlmoEarth-v1_2-Small \
+        --source_data '["https://sentinel.esa.int/web/sentinel/missions/sentinel-2"]' \
+        --zone_numbers '[10]'
 
     python -m rslp.main large_scale_embeddings predict \
         --inputs S2 \
         --projection_json '{"crs": "EPSG:32610", "x_resolution": 10, "y_resolution": -10}' \
         --bounds '[32768, -557056, 65536, -524288]' \
         --time_range '["2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+00:00"]' \
-        --out_path gs://BUCKET/embeddings/s2/2024/ \
-        --completed_path gs://BUCKET/embeddings/s2/2024_completed/ \
-        --checkpoint_path /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000
+        --store_path gs://BUCKET/embeddings/s2.zarr \
+        --completed_path gs://BUCKET/embeddings/s2_completed/ \
+        --checkpoint_path /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000 \
+        --time_index 0
 
-`bounds` can be any box whose extents are multiples of 2048 (it does not have to be a
-32768x32768 tile). `time_range` is `(T, T)` where T is the reference timestamp; the
-dataset config derives the twelve monthly mosaics over the year following T. By
+The `projection_json` must be the zone's northern CRS (EPSG:326NN). `bounds` can be
+any box whose extents are multiples of 2048 (it does not have to be a 32768x32768
+tile). `time_range` is `(T, T)` where T is the reference timestamp; the dataset config
+derives the twelve monthly mosaics over the year following T. `time_index` is the
+index of this year in the store's time axis (0 for the first year in `--years`). By
 default the scratch rslearn dataset is placed in a temporary directory and deleted;
-pass `--scratch_path /path/to/scratch/` to keep it for debugging.
+pass `--scratch_path /path/to/scratch/` to keep it for debugging, and
+`--debug_geotiff_path /path/` to also write per-window GeoTIFFs for inspection.
 
 
 Running at Scale
@@ -100,24 +139,51 @@ Running at Scale
 Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
 
 1. Build and push a Beaker image containing rslearn_projects (with the
-   `global-land-mask` dependency included).
+   `global-land-mask`, `zarr`, and `gcsfs` dependencies included).
 
-2. Write jobs to a Beaker queue, one per uncompleted tile:
+   Pin images by **Beaker image ID**, not by name. Images are immutable once
+   committed, but a name/tag can be reused or deleted, so a name does not identify
+   what actually ran. Record the ID and the commit it was built from together.
+
+   Two roles need different things from the image:
+
+   - **Workers** only execute `predict`. An older image keeps working for them as
+     long as the job arguments and the store layout have not changed, so there is no
+     need to rebuild workers for a supervisor-only change.
+   - **The supervisor** needs an image that contains `supervise`, including the
+     child-process cycle isolation (without it a hung Beaker RPC can stall the run
+     for hours). Verify a supervisor image on a short run before relying on it.
+
+   Validate a new image end-to-end before a long run: S2 -> forward pass -> int8
+   GeoZarr write, then check that the dequantized per-pixel L2 norm is ~= 1.0. That
+   catches a config-incompatible checkpoint and a broken write path in one pass.
+
+2. Create the store once, covering all reference years and zones:
+
+        python -m rslp.main large_scale_embeddings init_store \
+            --store_path gs://BUCKET/PREFIX/s2.zarr \
+            --years '[2021, 2022, 2023, 2024, 2025]' \
+            --model_url https://huggingface.co/allenai/OlmoEarth-v1_2-Small \
+            --source_data '["https://sentinel.esa.int/web/sentinel/missions/sentinel-2"]'
+
+3. Write jobs to a Beaker queue for one reference year, one job per uncompleted tile
+   (the year's time index is derived from the store's time axis):
 
         python -m rslp.main large_scale_embeddings write_jobs \
             --inputs S2 \
             --timestamp '2025-01-01T00:00:00+00:00' \
-            --out_path gs://ai2-olmoearth-embeddings-us-central1/large_scale_embeddings/20270721/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/ps1_ws16_s2/2025/ \
-            --completed_path gs://ai2-olmoearth-embeddings-us-central1/large_scale_embeddings/20270721/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/ps1_ws16_s2/2025_completed/ \
+            --store_path gs://BUCKET/PREFIX/s2.zarr \
+            --completed_path gs://BUCKET/PREFIX/s2_2025_completed/ \
             --checkpoint_path /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000 \
-            --queue_name favyen/rslp-large-scale-embeddings-queue
+            --queue_name USER/QUEUE
 
    The model settings (`--checkpoint_path`, `--patch_size`, `--window_size`,
    `--overlap_size`, `--compile_model`; see above) are recorded in each job.
    Without additional arguments this enumerates all land tiles globally (~8,700).
    Options to limit the extent:
 
-   - `--epsg_code 32610`: only one UTM zone.
+   - `--epsg_code 32610`: only the zone of this UTM EPSG code (326NN or 327NN both
+     map to zone NN).
    - `--wgs84_bounds '[-125.0, 45.0, -116.0, 49.0]'`: only tiles intersecting these
      WGS84 bounds.
    - `--geojson_fname data/large_scale_embeddings/initial_regions.geojson`: only
@@ -126,14 +192,14 @@ Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
      points in Greenland and coastal Antarctica; 88 tiles).
    - `--count 10`: randomly sample this many tiles.
 
-3. Launch workers on Beaker (WEKA must be mounted for the checkpoint). The
+4. Launch workers on Beaker (WEKA must be mounted for the checkpoint). The
    OlmoEarth Datasets data source needs `OEDATASETS_API_URL` (plain env var) and
    `DATASETS_API_TOKEN` (bearer token, read from the `LCC_DATASETS_API_TOKEN`
    Beaker secret which must exist in the `ai2/earth-systems` workspace):
 
         python -m rslp.main common launch \
-            --image_name favyen/rslpomp20260721b \
-            --queue_name favyen/rslp-large-scale-embeddings-queue \
+            --image_name USER/IMAGE \
+            --queue_name USER/QUEUE \
             --num_workers 4 \
             --gpus 1 \
             --priority urgent \
@@ -146,23 +212,7 @@ Jobs are distributed via a Beaker queue and processed by `rslp.common` workers.
 Progress can be monitored by counting marker files in `completed_path`. To retry
 failed tiles, simply run `write_jobs` again: completed tiles are excluded.
 
-Remember to use different `out_path`/`completed_path` per input variant, model
-settings (checkpoint and patch/window/overlap sizes), and reference timestamp.
-
-
-Quantization
-------------
-
-Embeddings are L2-normalized and then quantized following the AlphaEarth scheme (see
-`model.py`): `quantized = round(sign(x) * |x|^0.5 * 127.5)` clipped to [-127, 127],
-with -128 reserved for nodata. To recover approximate float embeddings:
-
-```python
-import numpy as np
-
-def dequantize(v: np.ndarray) -> np.ndarray:
-    x = v.astype(np.float32) / 127.5
-    return np.sign(x) * np.abs(x) ** 2.0
-```
-
-Pixels where all Sentinel-2 mosaics are empty are set to -128 in all bands.
+Run `write_jobs` once per reference year (each with its own `completed_path`), all
+targeting the same store. Use a different store per input variant and per set of model
+settings (checkpoint and patch/window/overlap sizes), since those change the
+embeddings.

--- a/rslp/large_scale_embeddings/README.md
+++ b/rslp/large_scale_embeddings/README.md
@@ -216,3 +216,119 @@ Run `write_jobs` once per reference year (each with its own `completed_path`), a
 targeting the same store. Use a different store per input variant and per set of model
 settings (checkpoint and patch/window/overlap sizes), since those change the
 embeddings.
+
+
+Supervised Runs (recommended)
+-----------------------------
+
+For anything longer than a few hours, use `supervise` instead of driving `write_jobs`
+and `launch` by hand. It loops: recompute the remaining work from the completion
+markers, top the queue up only if it is running shallow, and refill the worker pool.
+It exits when every tile has a marker.
+
+        python -m rslp.main large_scale_embeddings supervise \
+            --inputs S2 \
+            --years '[2024, 2025]' \
+            --store_path gs://BUCKET/PREFIX/s2.zarr \
+            --completed_path_template 'gs://BUCKET/PREFIX/s2_{year}_completed/' \
+            --queue_name USER/QUEUE \
+            --checkpoint_path /weka/dfive-default/helios/checkpoints/... \
+            --image_name USER/IMAGE \
+            --cluster '["ai2/jupiter","ai2/ceres"]' \
+            --geojson_fname data/large_scale_embeddings/initial_regions.geojson \
+            --job_size 8192 --num_workers 8
+
+Run it as a cheap CPU Beaker job, not from a workstation: it must outlive any single
+login session, and a laptop-side loop dies with the session (or silently hangs -- the
+Beaker client has no RPC timeout, so an in-process watchdog cannot bound it).
+
+
+Operational envelope
+--------------------
+
+Hard-won numbers from the 2024/2025 `initial_regions` run. Re-measure if the model,
+image, or cluster changes, but start here.
+
+**Size jobs to finish inside the preemption window.** Workers are preemptible and the
+GPU clusters are routinely at zero free slots, so jobs are interrupted constantly. A
+job that runs longer than the typical gap between preemptions never completes at all.
+Measured throughput was ~2.4 min per window end-to-end (~0.6 min materialize, ~1.8 min
+predict) at `patch_size=1`, `window_size=16` on an H100:
+
+    job_size   windows   ~duration   outcome
+       32768       256       ~9 h     never completed (always preempted first)
+        8192        16      ~38 min   completes reliably
+        4096         4      ~12 min   completes, but ~55% of the time is fixed overhead
+
+`job_size=8192` was the sweet spot. Smaller jobs survive better but pay model load and
+compile per job, so total GPU time rises.
+
+**Preemption is normal, not an error.** Exit 143 with `canceled_for` naming another job
+means preempted; retry is the correct response. Note also that `ai2/jupiter` uses
+"strict priority with unallocated-only backfill", so without an allocation your jobs
+are backfill and can be evicted at any priority.
+
+**Keep the queue shallow.** A queue entry claimed by a worker that then dies is not
+released back to the queue: entries were still CLAIMED 5 hours after being claimed, with
+no worker alive for the last 1.4 of those, and the queue API has no call to release one.
+They do eventually age out, since `status.expiry` is set from `expires_in_sec` (7 days
+by default), but a week is far longer than any job, so within a run that work is lost.
+`max_claimed_entries=1` makes it worse: a dead worker's claim permanently occupies that
+entry's only claim slot. `wait_timeout` on the queue is unrelated to this; it bounds how
+long a worker waits for work to appear. Untested: whether expiry deletes the entry or
+returns it to PENDING. Enqueuing a
+whole run up front therefore bleeds work steadily -- one run accumulated 327 orphaned
+entries. `supervise` enqueues only a small buffer and refills from the markers, which
+bounds the loss to about one entry per worker death.
+
+**`MATERIALIZE_PIPELINE_ARGS` pool sizes are the working default; changing them is
+untested.** Scaling them to the job's window count was tried and reverted, but the
+revert was based on a mismeasured elapsed time, so it is neither proven harmful nor
+proven safe. If you revisit it, note that materialize parallelizes over window x
+item-group units (each window pulls 12 monthly mosaics, so a 12-window job is ~144
+units, not 12), so sizing by window count alone under-parallelizes.
+
+**Measure elapsed time carefully.** These logs are emitted in the machine's local
+time, not UTC. Comparing a log timestamp against `date -u` silently adds the UTC
+offset -- doing so produced a "7 hours with zero completions" reading of what was
+actually 7 minutes, and a wrong conclusion about the pool sizes above. Prefer deltas
+between two timestamps from the same log, and remember a single job takes ~38 minutes
+at `job_size=8192`, so any window shorter than that tells you nothing.
+
+**Worker deaths are common and not yet explained.** Roughly 68% of attempts on an
+8-worker pool ended in SIGKILL (137) or SIGSEGV (139) rather than preemption (143).
+Memory pressure from co-location is the leading theory -- a single-GPU worker can share
+an 8-GPU node with seven siblings -- but it is unproven, and the materialize pool is
+*not* the cause. The cheapest experiment is to request more GPUs per worker so fewer
+land per node, which needs no code change. Vary one thing at a time and measure the
+completion rate; the failure is frequent enough that a few hours gives a clear signal.
+
+**Storage.** ~385 MB per written window on GCS (2048x2048x128 int8 at zstd level 1,
+measured compression ratio 0.717 on real embeddings, range 0.534-0.794). Roughly
+5.4 GB per `job_size=8192` block. Only shards intersecting land are written.
+
+**A smaller `job_size` also tightens AOI clipping.** Blocks outside the GeoJSON
+features are dropped, whereas a large tile merely intersecting a feature had all of its
+land crops processed. `initial_regions` covers ~7,700 windows/year at `job_size=8192`
+versus ~11,300 at 32768. That is usually desirable, but it means output extent is not
+comparable across `job_size` values.
+
+
+Quantization
+------------
+
+Embeddings are L2-normalized and then quantized following the AlphaEarth signed-power
+scheme (see `model.py`): `quantized = round(sign(x) * |x|^0.5 * 127.5)` clipped to
+[-127, 127], with -128 reserved for nodata. This is recorded in the store's
+`geoemb:quantization` metadata with `method: "signed_power"`. To recover approximate
+float embeddings:
+
+```python
+import numpy as np
+
+def dequantize(v: np.ndarray) -> np.ndarray:
+    x = v.astype(np.float32) / 127.5
+    return np.sign(x) * np.abs(x) ** 2.0
+```
+
+Pixels where all Sentinel-2 mosaics are empty are set to -128 in all bands.

--- a/rslp/large_scale_embeddings/__init__.py
+++ b/rslp/large_scale_embeddings/__init__.py
@@ -1,0 +1,9 @@
+"""Global quantized OlmoEarth embedding inference."""
+
+from .predict_pipeline import predict_pipeline
+from .write_jobs import write_jobs
+
+workflows = {
+    "predict": predict_pipeline,
+    "write_jobs": write_jobs,
+}

--- a/rslp/large_scale_embeddings/__init__.py
+++ b/rslp/large_scale_embeddings/__init__.py
@@ -1,9 +1,10 @@
 """Global quantized OlmoEarth embedding inference."""
 
 from .predict_pipeline import predict_pipeline
-from .write_jobs import write_jobs
+from .write_jobs import init_store, write_jobs
 
 workflows = {
+    "init_store": init_store,
     "predict": predict_pipeline,
     "write_jobs": write_jobs,
 }

--- a/rslp/large_scale_embeddings/__init__.py
+++ b/rslp/large_scale_embeddings/__init__.py
@@ -1,10 +1,13 @@
 """Global quantized OlmoEarth embedding inference."""
 
 from .predict_pipeline import predict_pipeline
+from .supervise import launch_supervisor, supervise
 from .write_jobs import init_store, write_jobs
 
 workflows = {
     "init_store": init_store,
+    "launch_supervisor": launch_supervisor,
     "predict": predict_pipeline,
+    "supervise": supervise,
     "write_jobs": write_jobs,
 }

--- a/rslp/large_scale_embeddings/model.py
+++ b/rslp/large_scale_embeddings/model.py
@@ -1,0 +1,109 @@
+"""Model components for quantized OlmoEarth embedding inference.
+
+The quantization scheme matches the power-based int8 scheme used for AlphaEarth
+Foundations embeddings (Brown et al. 2025, section S8.1) and by
+olmoearth_pretrain.evals.embedding_transforms: values are compressed with a signed
+square root, scaled to the int8 range, and rounded. The value -128 is never produced
+by the quantizer; it is reserved as the nodata value in the output GeoTIFFs.
+"""
+
+from typing import Any
+
+import torch
+from rslearn.models.component import FeatureMaps, Predictor
+from rslearn.train.model_context import ModelContext, ModelOutput
+
+QUANTIZE_POWER = 2.0
+QUANTIZE_SCALE = 127.5
+
+# Reserved nodata value for the int8 output rasters. quantize_embeddings clamps to
+# [-127, 127] so it never emits this value.
+NODATA_VALUE = -128
+
+
+def quantize_embeddings(embeddings: torch.Tensor) -> torch.Tensor:
+    """Quantize float embeddings to int8 using the power-based scheme.
+
+    The values are expected to be roughly in [-1, 1] (e.g. components of unit-norm
+    embedding vectors); values outside that range saturate at -127/127.
+
+    Args:
+        embeddings: float tensor of any shape.
+
+    Returns:
+        int8 tensor of the same shape, with values in [-127, 127].
+    """
+    sat = embeddings.abs().pow(1.0 / QUANTIZE_POWER) * embeddings.sign()
+    return (sat * QUANTIZE_SCALE).clamp(-127, 127).round().to(torch.int8)
+
+
+def dequantize_embeddings(quantized: torch.Tensor) -> torch.Tensor:
+    """Dequantize int8 embeddings back to float32.
+
+    Args:
+        quantized: int8 tensor produced by quantize_embeddings.
+
+    Returns:
+        float32 tensor approximating the original embeddings.
+    """
+    rescaled = quantized.float() / QUANTIZE_SCALE
+    return rescaled.abs().pow(QUANTIZE_POWER) * rescaled.sign()
+
+
+class QuantizedEmbeddingHead(Predictor):
+    """Head that L2-normalizes and int8-quantizes a feature map.
+
+    Like rslearn.train.tasks.embedding.EmbeddingHead, but the output is an int8
+    tensor suitable for writing to an int8 raster layer. Use with EmbeddingTask.
+    """
+
+    def __init__(self, l2_normalize: bool = True, epsilon: float = 1e-8):
+        """Create a new QuantizedEmbeddingHead.
+
+        Args:
+            l2_normalize: whether to L2-normalize each spatial position's embedding
+                vector (across the channel dimension) before quantization. The
+                power-based quantization scheme assumes values roughly in [-1, 1], so
+                this should be enabled unless the model already outputs unit-norm
+                embeddings.
+            epsilon: minimum norm to avoid division by zero.
+        """
+        super().__init__()
+        self.l2_normalize = l2_normalize
+        self.epsilon = epsilon
+
+    def forward(
+        self,
+        intermediates: Any,
+        context: ModelContext,
+        targets: list[dict[str, Any]] | None = None,
+    ) -> ModelOutput:
+        """Return the quantized feature map along with a dummy loss.
+
+        Args:
+            intermediates: output from the previous model component, which must be a
+                FeatureMaps consisting of a single BCHW feature map.
+            context: the model context.
+            targets: the targets (ignored).
+
+        Returns:
+            model output with the int8-quantized feature map along with a dummy loss.
+        """
+        if not isinstance(intermediates, FeatureMaps):
+            raise ValueError("input to QuantizedEmbeddingHead must be a FeatureMaps")
+        if len(intermediates.feature_maps) != 1:
+            raise ValueError(
+                "input to QuantizedEmbeddingHead must have one feature map, "
+                f"but got {len(intermediates.feature_maps)}"
+            )
+
+        features = intermediates.feature_maps[0]
+        if self.l2_normalize:
+            features = features / features.norm(dim=1, keepdim=True).clamp(
+                min=self.epsilon
+            )
+
+        return ModelOutput(
+            outputs=quantize_embeddings(features),
+            loss_dict={"loss": 0},
+        )

--- a/rslp/large_scale_embeddings/predict_pipeline.py
+++ b/rslp/large_scale_embeddings/predict_pipeline.py
@@ -1,0 +1,403 @@
+"""Scaled inference pipeline for global OlmoEarth embeddings.
+
+This computes 10 m/pixel, 128-dimensional, int8-quantized OlmoEarth embeddings over
+one tile (a part of a UTM zone) by creating PATCH_SIZE windows, materializing
+Sentinel-2 (and optionally Sentinel-1) mosaics from the OlmoEarth Datasets source,
+running the model, and uploading one GeoTIFF per window to out_path. A per-tile
+marker file is written to completed_path once the tile is done, recording which
+crops were written and which were skipped.
+
+Windows that don't intersect the zone's canonical wedge or that are entirely ocean
+are skipped (see tiling.py). Embedding pixels where all Sentinel-2 mosaics are empty
+are set to the nodata value (-128).
+
+This module is tile-size-agnostic: it accepts any ``bounds`` whose extents are
+multiples of PATCH_SIZE. The fixed 32768x32768 tiling lives only in write_jobs.py.
+
+Note that different input variants (see EmbeddingInputs) produce different
+embeddings, so each variant must use its own out_path and completed_path.
+"""
+
+import json
+import shutil
+import tempfile
+from datetime import datetime, timedelta
+from enum import Enum
+
+import numpy as np
+from rasterio.enums import Resampling
+from rslearn.const import WGS84_PROJECTION
+from rslearn.dataset import Dataset, Window
+from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
+from rslearn.utils.raster_array import RasterArray, RasterMetadata
+from rslearn.utils.raster_format import GeotiffRasterFormat
+from shapely import box as shapely_box
+from upath import UPath
+
+from rslp.log_utils import get_logger
+from rslp.utils.rslearn import (
+    ApplyWindowsArgs,
+    IngestArgs,
+    MaterializeArgs,
+    MaterializePipelineArgs,
+    PrepareArgs,
+    materialize_dataset,
+    run_model_predict,
+)
+
+from .model import NODATA_VALUE
+from .tiling import get_zone_wedge, list_kept_crops
+
+logger = get_logger(__name__)
+
+
+class EmbeddingInputs(Enum):
+    """Which input modalities the embeddings are computed from."""
+
+    S2 = "s2"
+    S2_S1 = "s2_s1"
+
+
+DATASET_CONFIG_FNAME = "data/large_scale_embeddings/{inputs}.json"
+MODEL_CONFIG_FNAME = "data/large_scale_embeddings/{inputs}.yaml"
+
+# Per-window size. The tile size (passed via bounds) must be a multiple of this.
+PATCH_SIZE = 2048
+RESOLUTION = 10
+
+PREDICTION_GROUP = "predict"
+
+SENTINEL2_LAYER = "sentinel2_l2a"
+# Band order in the dataset config band set (used to read materialized mosaics when
+# computing the validity mask).
+SENTINEL2_BANDS = [
+    "B01",
+    "B02",
+    "B03",
+    "B04",
+    "B05",
+    "B06",
+    "B07",
+    "B08",
+    "B8A",
+    "B09",
+    "B11",
+    "B12",
+]
+
+OUTPUT_LAYER = "output"
+EMBEDDING_DIM = 128
+# The dataset configs use num_bands, for which rslearn generates band names B0, B1,
+# etc.
+OUTPUT_BANDS = [f"B{band_idx}" for band_idx in range(EMBEDDING_DIM)]
+
+MATERIALIZE_PIPELINE_ARGS = MaterializePipelineArgs(
+    disabled_layers=[],
+    # Use initial job for prepare since it involves caching steps that should only be
+    # performed once.
+    prepare_args=PrepareArgs(
+        apply_windows_args=ApplyWindowsArgs(
+            group=PREDICTION_GROUP, workers=32, use_initial_job=True
+        )
+    ),
+    # The OlmoEarth Datasets source sets ingest=false, so this step is a no-op, but we
+    # keep it for parity with the standard materialize pipeline.
+    ingest_args=IngestArgs(
+        ignore_errors=False,
+        apply_windows_args=ApplyWindowsArgs(
+            group=PREDICTION_GROUP, workers=32, use_initial_job=False
+        ),
+    ),
+    materialize_args=MaterializeArgs(
+        ignore_errors=False,
+        retry_max_attempts=3,
+        retry_backoff=timedelta(seconds=5),
+        apply_windows_args=ApplyWindowsArgs(
+            group=PREDICTION_GROUP, workers=128, use_initial_job=False
+        ),
+    ),
+)
+
+
+def get_output_fname(
+    out_path: str, projection: Projection, bounds: PixelBounds
+) -> UPath:
+    """Get the output GeoTIFF filename for one PATCH_SIZE crop.
+
+    Args:
+        out_path: the output directory.
+        projection: the projection of the crop.
+        bounds: the pixel bounds of the crop.
+
+    Returns:
+        the output filename.
+    """
+    return UPath(out_path) / f"{str(projection.crs)}_{bounds[0]}_{bounds[1]}.tif"
+
+
+def get_marker_fname(
+    completed_path: str, projection: Projection, bounds: PixelBounds
+) -> UPath:
+    """Get the per-tile completion marker filename.
+
+    Args:
+        completed_path: the directory for completion markers.
+        projection: the projection of the tile.
+        bounds: the pixel bounds of the tile.
+
+    Returns:
+        the marker filename.
+    """
+    return UPath(completed_path) / f"{str(projection.crs)}_{bounds[0]}_{bounds[1]}.json"
+
+
+def _crop_crosses_bad_longitude(projection: Projection, bounds: PixelBounds) -> bool:
+    """Check whether a crop is too close to or crossing 0/180 longitude.
+
+    Mosaics for such crops are unreliable (items on the other side of the
+    antimeridian may be matched), so we skip them like the other scaled inference
+    pipelines do.
+
+    Args:
+        projection: the UTM projection.
+        bounds: the pixel bounds of the crop.
+
+    Returns:
+        whether the crop should be skipped.
+    """
+    epsilon = 1e-4
+    wgs84_geom = STGeometry(projection, shapely_box(*bounds), None).to_projection(
+        WGS84_PROJECTION
+    )
+    wgs84_bounds = wgs84_geom.shp.bounds
+    if wgs84_bounds[0] <= -180 + epsilon or wgs84_bounds[2] >= 180 - epsilon:
+        return True
+    if wgs84_bounds[0] < -90 and wgs84_bounds[2] > 90:
+        return True
+    return False
+
+
+def _upload_window_output(
+    window: Window,
+    projection: Projection,
+    out_fname: UPath,
+) -> None:
+    """Upload one window's embedding raster to the output path.
+
+    Reads the int8 embedding raster from the scratch dataset, sets pixels where all
+    Sentinel-2 mosaics are empty to NODATA_VALUE, and writes a tiled+compressed
+    GeoTIFF to the output path.
+
+    Args:
+        window: the window to upload.
+        projection: the UTM projection (must match the window projection).
+        out_fname: the output filename.
+    """
+    raster = window.data.read_raster(
+        OUTPUT_LAYER,
+        OUTPUT_BANDS,
+        GeotiffRasterFormat(),
+        resampling=Resampling.nearest,
+    )
+    embeddings = raster.get_chw_array().copy()
+
+    # A pixel is valid if any band is nonzero in any of the Sentinel-2 mosaics.
+    valid = np.zeros(embeddings.shape[1:], dtype=bool)
+    for layer_name, group_idx in window.list_completed_layers():
+        if layer_name != SENTINEL2_LAYER:
+            continue
+        s2_array = window.data.read_raster(
+            SENTINEL2_LAYER,
+            SENTINEL2_BANDS,
+            GeotiffRasterFormat(),
+            group_idx=group_idx,
+            resampling=Resampling.nearest,
+        ).get_chw_array()
+        valid |= (s2_array != 0).any(axis=0)
+    embeddings[:, ~valid] = NODATA_VALUE
+
+    raster_format = GeotiffRasterFormat(
+        always_enable_tiling=True,
+        block_size=512,
+        geotiff_options={"compress": "zstd"},
+    )
+    raster_format.encode_raster(
+        out_fname.parent,
+        projection,
+        window.bounds,
+        RasterArray(
+            chw_array=embeddings,
+            metadata=RasterMetadata(nodata_value=NODATA_VALUE),
+        ),
+        fname=out_fname.name,
+    )
+
+
+def predict_pipeline(
+    inputs: EmbeddingInputs,
+    projection_json: str,
+    bounds: PixelBounds,
+    time_range: tuple[datetime, datetime],
+    out_path: str,
+    completed_path: str,
+    scratch_path: str | None = None,
+) -> None:
+    """Compute quantized OlmoEarth embeddings over one tile.
+
+    Args:
+        inputs: which input variant to use. Different variants produce different
+            embeddings so they must use different out_path/completed_path.
+        projection_json: JSON-encoded projection, normally a UTM zone with 10 m/pixel
+            resolution.
+        bounds: pixel coordinates within the projection on which to compute outputs.
+            Each value must be a multiple of PATCH_SIZE.
+        time_range: the reference timestamp as (T, T). The layer time_offset/duration
+            derive the twelve monthly mosaics over the following year from this.
+        out_path: directory to write one embedding GeoTIFF per PATCH_SIZE crop.
+        completed_path: directory to write per-tile completion markers.
+        scratch_path: optional directory to store the scratch rslearn dataset in
+            directly, and keep it afterward (useful for debugging). By default, a
+            temporary directory is used and deleted when the tile is done.
+    """
+    projection = Projection.deserialize(json.loads(projection_json))
+
+    marker_fname = get_marker_fname(completed_path, projection, bounds)
+    if marker_fname.exists():
+        logger.info(f"marker file {marker_fname} already exists")
+        return
+
+    if scratch_path is None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _process_tile(
+                inputs=inputs,
+                projection=projection,
+                bounds=bounds,
+                time_range=time_range,
+                out_path=out_path,
+                marker_fname=marker_fname,
+                ds_path=UPath(tmp_dir) / "dataset",
+            )
+    else:
+        _process_tile(
+            inputs=inputs,
+            projection=projection,
+            bounds=bounds,
+            time_range=time_range,
+            out_path=out_path,
+            marker_fname=marker_fname,
+            ds_path=UPath(scratch_path),
+        )
+
+
+def _process_tile(
+    inputs: EmbeddingInputs,
+    projection: Projection,
+    bounds: PixelBounds,
+    time_range: tuple[datetime, datetime],
+    out_path: str,
+    marker_fname: UPath,
+    ds_path: UPath,
+) -> None:
+    """Process one tile using the given scratch dataset path.
+
+    See predict_pipeline for details.
+
+    Args:
+        inputs: which input variant to use.
+        projection: the projection of the tile.
+        bounds: the pixel bounds of the tile.
+        time_range: the reference timestamp as (T, T).
+        out_path: directory to write one embedding GeoTIFF per PATCH_SIZE crop.
+        marker_fname: the per-tile completion marker filename to write.
+        ds_path: where to create the temporary rslearn dataset.
+    """
+    # Initialize an rslearn dataset in scratch from the predict dataset config.
+    dataset_config_fname = DATASET_CONFIG_FNAME.format(inputs=inputs.value)
+    model_config_fname = MODEL_CONFIG_FNAME.format(inputs=inputs.value)
+    ds_path.mkdir(parents=True)
+    shutil.copyfile(dataset_config_fname, ds_path / "config.json")
+
+    # Determine which PATCH_SIZE crops to process (see tiling.py), and additionally
+    # skip crops too close to 0/180 longitude.
+    wedge = get_zone_wedge(projection.crs, projection.x_resolution)
+    kept_crops = list_kept_crops(projection, bounds, PATCH_SIZE, wedge=wedge)
+
+    dataset = Dataset(ds_path)
+    windows: list[Window] = []
+    skipped_longitude: list[list[int]] = []
+    for crop_bounds in kept_crops:
+        if _crop_crosses_bad_longitude(projection, crop_bounds):
+            logger.debug(
+                "skipping crop at %s because it is too close to 0/180 longitude",
+                crop_bounds,
+            )
+            skipped_longitude.append([crop_bounds[0], crop_bounds[1]])
+            continue
+        window = Window(
+            storage=dataset.storage,
+            group=PREDICTION_GROUP,
+            name=f"{crop_bounds[0] // PATCH_SIZE}_{crop_bounds[1] // PATCH_SIZE}",
+            projection=projection,
+            bounds=crop_bounds,
+            time_range=time_range,
+        )
+        window.save()
+        windows.append(window)
+
+    written: list[list[int]] = []
+    skipped_no_data: list[list[int]] = []
+
+    if len(windows) > 0:
+        # Materialize imagery for the windows.
+        logger.info("materialize dataset")
+        materialize_dataset(
+            ds_path, materialize_pipeline_args=MATERIALIZE_PIPELINE_ARGS
+        )
+
+        # Run the model only if at least one window has materialized imagery.
+        completed_fnames = list(
+            ds_path.glob(
+                f"windows/{PREDICTION_GROUP}/*/layers/{SENTINEL2_LAYER}/completed"
+            )
+        )
+        if len(completed_fnames) == 0:
+            logger.info("skipping prediction since no windows seem to have data")
+        else:
+            run_model_predict(model_config_fname, ds_path)
+
+        # Upload each window's embedding raster.
+        for window in windows:
+            crop_offset = [window.bounds[0], window.bounds[1]]
+            if not window.is_layer_completed(OUTPUT_LAYER):
+                # Required input layers must have been missing, so no prediction was
+                # made for this window.
+                skipped_no_data.append(crop_offset)
+                continue
+            out_fname = get_output_fname(out_path, projection, window.bounds)
+            _upload_window_output(window, projection, out_fname)
+            written.append(crop_offset)
+        logger.info(
+            "wrote %d crops (%d skipped due to missing data)",
+            len(written),
+            len(skipped_no_data),
+        )
+    else:
+        logger.info("no crops to process for this tile")
+
+    # Write the per-tile completion marker.
+    marker = {
+        "projection": projection.serialize(),
+        "bounds": list(bounds),
+        "time_range": [time_range[0].isoformat(), time_range[1].isoformat()],
+        "written": written,
+        "skipped_no_data": skipped_no_data,
+        "skipped_longitude": skipped_longitude,
+        "num_filtered_crops": (bounds[2] - bounds[0])
+        * (bounds[3] - bounds[1])
+        // (PATCH_SIZE * PATCH_SIZE)
+        - len(kept_crops),
+    }
+    marker_fname.parent.mkdir(parents=True, exist_ok=True)
+    with marker_fname.open("w") as f:
+        json.dump(marker, f)
+    logger.info("wrote marker file %s", marker_fname)

--- a/rslp/large_scale_embeddings/predict_pipeline.py
+++ b/rslp/large_scale_embeddings/predict_pipeline.py
@@ -19,6 +19,7 @@ embeddings, so each variant must use its own out_path and completed_path.
 """
 
 import json
+import multiprocessing
 import shutil
 import tempfile
 from datetime import datetime, timedelta
@@ -29,6 +30,7 @@ from rasterio.enums import Resampling
 from rslearn.const import WGS84_PROJECTION
 from rslearn.dataset import Dataset, Window
 from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
+from rslearn.utils.mp import star_imap_unordered
 from rslearn.utils.raster_array import RasterArray, RasterMetadata
 from rslearn.utils.raster_format import GeotiffRasterFormat
 from shapely import box as shapely_box
@@ -96,22 +98,26 @@ MATERIALIZE_PIPELINE_ARGS = MaterializePipelineArgs(
     # Use initial job for prepare since it involves caching steps that should only be
     # performed once.
     prepare_args=PrepareArgs(
+        retry_max_attempts=10,
+        retry_backoff=timedelta(seconds=10),
         apply_windows_args=ApplyWindowsArgs(
             group=PREDICTION_GROUP, workers=32, use_initial_job=True
-        )
+        ),
     ),
     # The OlmoEarth Datasets source sets ingest=false, so this step is a no-op, but we
     # keep it for parity with the standard materialize pipeline.
     ingest_args=IngestArgs(
         ignore_errors=False,
+        retry_max_attempts=10,
+        retry_backoff=timedelta(seconds=10),
         apply_windows_args=ApplyWindowsArgs(
             group=PREDICTION_GROUP, workers=32, use_initial_job=False
         ),
     ),
     materialize_args=MaterializeArgs(
         ignore_errors=False,
-        retry_max_attempts=3,
-        retry_backoff=timedelta(seconds=5),
+        retry_max_attempts=10,
+        retry_backoff=timedelta(seconds=10),
         apply_windows_args=ApplyWindowsArgs(
             group=PREDICTION_GROUP, workers=128, use_initial_job=False
         ),
@@ -185,7 +191,7 @@ def _upload_window_output(
     """Upload one window's embedding raster to the output path.
 
     Reads the int8 embedding raster from the scratch dataset, sets pixels where all
-    Sentinel-2 mosaics are empty to NODATA_VALUE, and writes a tiled+compressed
+    Sentinel-2 mosaics are empty to NODATA_VALUE, and writes a tiled (uncompressed)
     GeoTIFF to the output path.
 
     Args:
@@ -219,7 +225,7 @@ def _upload_window_output(
     raster_format = GeotiffRasterFormat(
         always_enable_tiling=True,
         block_size=512,
-        geotiff_options={"compress": "zstd"},
+        geotiff_options={"compress": "none"},
     )
     raster_format.encode_raster(
         out_fname.parent,
@@ -233,6 +239,32 @@ def _upload_window_output(
     )
 
 
+def _upload_window_by_name(
+    ds_path: UPath,
+    window_name: str,
+    out_path: str,
+) -> None:
+    """Load one window from the scratch dataset and upload its embedding raster.
+
+    This is the multiprocessing worker for the upload step; the window is reloaded by
+    name so that only picklable arguments cross the process boundary.
+
+    Args:
+        ds_path: the scratch dataset path.
+        window_name: the name of the window to upload.
+        out_path: the output directory.
+    """
+    dataset = Dataset(ds_path)
+    windows = dataset.load_windows(groups=[PREDICTION_GROUP], names=[window_name])
+    if len(windows) != 1:
+        raise ValueError(
+            f"expected one window named {window_name} but got {len(windows)}"
+        )
+    window = windows[0]
+    out_fname = get_output_fname(out_path, window.projection, window.bounds)
+    _upload_window_output(window, window.projection, out_fname)
+
+
 def predict_pipeline(
     inputs: EmbeddingInputs,
     projection_json: str,
@@ -241,6 +273,7 @@ def predict_pipeline(
     out_path: str,
     completed_path: str,
     scratch_path: str | None = None,
+    upload_workers: int = 16,
 ) -> None:
     """Compute quantized OlmoEarth embeddings over one tile.
 
@@ -258,6 +291,8 @@ def predict_pipeline(
         scratch_path: optional directory to store the scratch rslearn dataset in
             directly, and keep it afterward (useful for debugging). By default, a
             temporary directory is used and deleted when the tile is done.
+        upload_workers: number of worker processes for uploading the per-crop
+            embedding GeoTIFFs.
     """
     projection = Projection.deserialize(json.loads(projection_json))
 
@@ -276,6 +311,7 @@ def predict_pipeline(
                 out_path=out_path,
                 marker_fname=marker_fname,
                 ds_path=UPath(tmp_dir) / "dataset",
+                upload_workers=upload_workers,
             )
     else:
         _process_tile(
@@ -286,6 +322,7 @@ def predict_pipeline(
             out_path=out_path,
             marker_fname=marker_fname,
             ds_path=UPath(scratch_path),
+            upload_workers=upload_workers,
         )
 
 
@@ -297,6 +334,7 @@ def _process_tile(
     out_path: str,
     marker_fname: UPath,
     ds_path: UPath,
+    upload_workers: int,
 ) -> None:
     """Process one tile using the given scratch dataset path.
 
@@ -310,6 +348,8 @@ def _process_tile(
         out_path: directory to write one embedding GeoTIFF per PATCH_SIZE crop.
         marker_fname: the per-tile completion marker filename to write.
         ds_path: where to create the temporary rslearn dataset.
+        upload_workers: number of worker processes for uploading the per-crop
+            embedding GeoTIFFs.
     """
     # Initialize an rslearn dataset in scratch from the predict dataset config.
     dataset_config_fname = DATASET_CONFIG_FNAME.format(inputs=inputs.value)
@@ -340,6 +380,7 @@ def _process_tile(
             projection=projection,
             bounds=crop_bounds,
             time_range=time_range,
+            data_factory=dataset.window_data_storage_factory,
         )
         window.save()
         windows.append(window)
@@ -365,7 +406,11 @@ def _process_tile(
         else:
             run_model_predict(model_config_fname, ds_path)
 
-        # Upload each window's embedding raster.
+        # Upload each window's embedding raster. The uploads are handled by a pool
+        # of worker processes since converting and uploading the rasters is slow. We
+        # use the forkserver context because the CUDA context initialized by
+        # run_model_predict above cannot be safely forked.
+        upload_kwargs: list[dict] = []
         for window in windows:
             crop_offset = [window.bounds[0], window.bounds[1]]
             if not window.is_layer_completed(OUTPUT_LAYER):
@@ -373,9 +418,20 @@ def _process_tile(
                 # made for this window.
                 skipped_no_data.append(crop_offset)
                 continue
-            out_fname = get_output_fname(out_path, projection, window.bounds)
-            _upload_window_output(window, projection, out_fname)
+            upload_kwargs.append(
+                dict(ds_path=ds_path, window_name=window.name, out_path=out_path)
+            )
             written.append(crop_offset)
+        if len(upload_kwargs) > 0:
+            pool = multiprocessing.get_context("forkserver").Pool(upload_workers)
+            try:
+                for _ in star_imap_unordered(
+                    pool, _upload_window_by_name, upload_kwargs
+                ):
+                    pass
+            finally:
+                pool.close()
+                pool.join()
         logger.info(
             "wrote %d crops (%d skipped due to missing data)",
             len(written),

--- a/rslp/large_scale_embeddings/predict_pipeline.py
+++ b/rslp/large_scale_embeddings/predict_pipeline.py
@@ -14,8 +14,9 @@ are set to the nodata value (-128).
 This module is tile-size-agnostic: it accepts any ``bounds`` whose extents are
 multiples of PATCH_SIZE. The fixed 32768x32768 tiling lives only in write_jobs.py.
 
-Note that different input variants (see EmbeddingInputs) produce different
-embeddings, so each variant must use its own out_path and completed_path.
+Note that different input variants (see EmbeddingInputs), checkpoints, and model
+settings (patch_size/window_size/overlap_size) produce different embeddings, so each
+combination must use its own out_path and completed_path.
 """
 
 import json
@@ -26,6 +27,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 
 import numpy as np
+import yaml
 from rasterio.enums import Resampling
 from rslearn.const import WGS84_PROJECTION
 from rslearn.dataset import Dataset, Window
@@ -125,6 +127,63 @@ MATERIALIZE_PIPELINE_ARGS = MaterializePipelineArgs(
 )
 
 
+def _get_model_extra_args(
+    model_config_fname: str,
+    checkpoint_path: str,
+    patch_size: int,
+    window_size: int,
+    overlap_size: int,
+    compile_model: bool,
+) -> list[str]:
+    """Get the extra arguments to pass to rslearn model predict.
+
+    These override the defaults in the model config file. The encoder and callbacks
+    are list-valued so individual entries cannot be overridden via jsonargparse dotted
+    keys; instead, the corresponding lists are loaded from the model config, updated,
+    and passed whole as JSON.
+
+    Args:
+        model_config_fname: the model configuration file.
+        checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
+        patch_size: the encoder patch size (yields one embedding per patch_size
+            pixels).
+        window_size: the size of the crops the model operates on.
+        overlap_size: overlap in pixels between adjacent crops.
+        compile_model: whether to compile the encoder transformer blocks.
+
+    Returns:
+        list of arguments to pass to rslearn model predict.
+    """
+    with open(model_config_fname) as f:
+        model_config = yaml.safe_load(f)
+
+    # Set the checkpoint path, patch size, and compilation flag on the OlmoEarth
+    # encoder (the first and only encoder entry).
+    encoder = model_config["model"]["init_args"]["model"]["init_args"]["encoder"]
+    encoder[0]["init_args"]["checkpoint_path"] = checkpoint_path
+    encoder[0]["init_args"]["patch_size"] = patch_size
+    encoder[0]["init_args"]["compile_model"] = compile_model
+
+    # Set the merger options on the RslearnWriter callback (the first and only
+    # callback entry). The merger operates at the output resolution, which is
+    # 1/patch_size of the input resolution.
+    callbacks = model_config["trainer"]["callbacks"]
+    merger = callbacks[0]["init_args"]["merger"]
+    merger["init_args"]["downsample_factor"] = patch_size
+    merger["init_args"]["overlap_pixels"] = overlap_size // patch_size
+
+    return [
+        "--model.init_args.model.init_args.encoder",
+        json.dumps(encoder),
+        "--trainer.callbacks",
+        json.dumps(callbacks),
+        "--data.init_args.default_config.crop_size",
+        str(window_size),
+        "--data.init_args.predict_config.overlap_pixels",
+        str(overlap_size),
+    ]
+
+
 def get_output_fname(
     out_path: str, projection: Projection, bounds: PixelBounds
 ) -> UPath:
@@ -187,6 +246,7 @@ def _upload_window_output(
     window: Window,
     projection: Projection,
     out_fname: UPath,
+    patch_size: int,
 ) -> None:
     """Upload one window's embedding raster to the output path.
 
@@ -198,17 +258,39 @@ def _upload_window_output(
         window: the window to upload.
         projection: the UTM projection (must match the window projection).
         out_fname: the output filename.
+        patch_size: the encoder patch size. The embedding raster is at 1/patch_size
+            of the window resolution.
     """
+    # The embedding raster is at 1/patch_size of the window resolution.
+    out_projection = Projection(
+        projection.crs,
+        projection.x_resolution * patch_size,
+        projection.y_resolution * patch_size,
+    )
+    out_bounds = (
+        window.bounds[0] // patch_size,
+        window.bounds[1] // patch_size,
+        window.bounds[2] // patch_size,
+        window.bounds[3] // patch_size,
+    )
     raster = window.data.read_raster(
         OUTPUT_LAYER,
         OUTPUT_BANDS,
         GeotiffRasterFormat(),
+        projection=out_projection,
+        bounds=out_bounds,
         resampling=Resampling.nearest,
     )
     embeddings = raster.get_chw_array().copy()
 
     # A pixel is valid if any band is nonzero in any of the Sentinel-2 mosaics.
-    valid = np.zeros(embeddings.shape[1:], dtype=bool)
+    valid = np.zeros(
+        (
+            window.bounds[3] - window.bounds[1],
+            window.bounds[2] - window.bounds[0],
+        ),
+        dtype=bool,
+    )
     for layer_name, group_idx in window.list_completed_layers():
         if layer_name != SENTINEL2_LAYER:
             continue
@@ -220,6 +302,15 @@ def _upload_window_output(
             resampling=Resampling.nearest,
         ).get_chw_array()
         valid |= (s2_array != 0).any(axis=0)
+    # Downsample the validity mask to the output resolution: an output pixel is
+    # valid if any input pixel in its patch is valid.
+    if patch_size > 1:
+        valid = valid.reshape(
+            valid.shape[0] // patch_size,
+            patch_size,
+            valid.shape[1] // patch_size,
+            patch_size,
+        ).any(axis=(1, 3))
     embeddings[:, ~valid] = NODATA_VALUE
 
     raster_format = GeotiffRasterFormat(
@@ -229,8 +320,8 @@ def _upload_window_output(
     )
     raster_format.encode_raster(
         out_fname.parent,
-        projection,
-        window.bounds,
+        out_projection,
+        out_bounds,
         RasterArray(
             chw_array=embeddings,
             metadata=RasterMetadata(nodata_value=NODATA_VALUE),
@@ -243,6 +334,7 @@ def _upload_window_by_name(
     ds_path: UPath,
     window_name: str,
     out_path: str,
+    patch_size: int,
 ) -> None:
     """Load one window from the scratch dataset and upload its embedding raster.
 
@@ -253,6 +345,7 @@ def _upload_window_by_name(
         ds_path: the scratch dataset path.
         window_name: the name of the window to upload.
         out_path: the output directory.
+        patch_size: the encoder patch size.
     """
     dataset = Dataset(ds_path)
     windows = dataset.load_windows(groups=[PREDICTION_GROUP], names=[window_name])
@@ -262,7 +355,7 @@ def _upload_window_by_name(
         )
     window = windows[0]
     out_fname = get_output_fname(out_path, window.projection, window.bounds)
-    _upload_window_output(window, window.projection, out_fname)
+    _upload_window_output(window, window.projection, out_fname, patch_size)
 
 
 def predict_pipeline(
@@ -272,6 +365,11 @@ def predict_pipeline(
     time_range: tuple[datetime, datetime],
     out_path: str,
     completed_path: str,
+    checkpoint_path: str,
+    patch_size: int = 1,
+    window_size: int = 16,
+    overlap_size: int = 4,
+    compile_model: bool = True,
     scratch_path: str | None = None,
     upload_workers: int = 16,
 ) -> None:
@@ -288,12 +386,39 @@ def predict_pipeline(
             derive the twelve monthly mosaics over the following year from this.
         out_path: directory to write one embedding GeoTIFF per PATCH_SIZE crop.
         completed_path: directory to write per-tile completion markers.
+        checkpoint_path: the OlmoEarth checkpoint to compute embeddings with, e.g.
+            /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000.
+            Different checkpoints produce different embeddings so they must use
+            different out_path/completed_path (same for patch_size, window_size, and
+            overlap_size below).
+        patch_size: the encoder patch size; yields one 128-dimensional embedding per
+            patch_size x patch_size pixels (so the output rasters are at 1/patch_size
+            of the window resolution).
+        window_size: the size of the crops the model operates on (much bigger than 16
+            fails with the 12 monthly inputs at patch_size=1 due to GPU memory
+            constraints).
+        overlap_size: overlap in pixels between adjacent crops, to mitigate embedding
+            seams at crop boundaries.
+        compile_model: whether to compile the encoder transformer blocks.
         scratch_path: optional directory to store the scratch rslearn dataset in
             directly, and keep it afterward (useful for debugging). By default, a
             temporary directory is used and deleted when the tile is done.
         upload_workers: number of worker processes for uploading the per-crop
             embedding GeoTIFFs.
     """
+    if PATCH_SIZE % patch_size != 0:
+        raise ValueError(f"patch_size must divide {PATCH_SIZE}, got {patch_size}")
+    if window_size % patch_size != 0:
+        raise ValueError(
+            f"window_size ({window_size}) must be a multiple of patch_size "
+            f"({patch_size})"
+        )
+    if overlap_size % patch_size != 0:
+        raise ValueError(
+            f"overlap_size ({overlap_size}) must be a multiple of patch_size "
+            f"({patch_size})"
+        )
+
     projection = Projection.deserialize(json.loads(projection_json))
 
     marker_fname = get_marker_fname(completed_path, projection, bounds)
@@ -311,6 +436,11 @@ def predict_pipeline(
                 out_path=out_path,
                 marker_fname=marker_fname,
                 ds_path=UPath(tmp_dir) / "dataset",
+                checkpoint_path=checkpoint_path,
+                patch_size=patch_size,
+                window_size=window_size,
+                overlap_size=overlap_size,
+                compile_model=compile_model,
                 upload_workers=upload_workers,
             )
     else:
@@ -322,6 +452,11 @@ def predict_pipeline(
             out_path=out_path,
             marker_fname=marker_fname,
             ds_path=UPath(scratch_path),
+            checkpoint_path=checkpoint_path,
+            patch_size=patch_size,
+            window_size=window_size,
+            overlap_size=overlap_size,
+            compile_model=compile_model,
             upload_workers=upload_workers,
         )
 
@@ -334,6 +469,11 @@ def _process_tile(
     out_path: str,
     marker_fname: UPath,
     ds_path: UPath,
+    checkpoint_path: str,
+    patch_size: int,
+    window_size: int,
+    overlap_size: int,
+    compile_model: bool,
     upload_workers: int,
 ) -> None:
     """Process one tile using the given scratch dataset path.
@@ -348,6 +488,11 @@ def _process_tile(
         out_path: directory to write one embedding GeoTIFF per PATCH_SIZE crop.
         marker_fname: the per-tile completion marker filename to write.
         ds_path: where to create the temporary rslearn dataset.
+        checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
+        patch_size: the encoder patch size.
+        window_size: the size of the crops the model operates on.
+        overlap_size: overlap in pixels between adjacent crops.
+        compile_model: whether to compile the encoder transformer blocks.
         upload_workers: number of worker processes for uploading the per-crop
             embedding GeoTIFFs.
     """
@@ -404,7 +549,18 @@ def _process_tile(
         if len(completed_fnames) == 0:
             logger.info("skipping prediction since no windows seem to have data")
         else:
-            run_model_predict(model_config_fname, ds_path)
+            run_model_predict(
+                model_config_fname,
+                ds_path,
+                extra_args=_get_model_extra_args(
+                    model_config_fname=model_config_fname,
+                    checkpoint_path=checkpoint_path,
+                    patch_size=patch_size,
+                    window_size=window_size,
+                    overlap_size=overlap_size,
+                    compile_model=compile_model,
+                ),
+            )
 
         # Upload each window's embedding raster. The uploads are handled by a pool
         # of worker processes since converting and uploading the rasters is slow. We
@@ -419,7 +575,12 @@ def _process_tile(
                 skipped_no_data.append(crop_offset)
                 continue
             upload_kwargs.append(
-                dict(ds_path=ds_path, window_name=window.name, out_path=out_path)
+                dict(
+                    ds_path=ds_path,
+                    window_name=window.name,
+                    out_path=out_path,
+                    patch_size=patch_size,
+                )
             )
             written.append(crop_offset)
         if len(upload_kwargs) > 0:

--- a/rslp/large_scale_embeddings/predict_pipeline.py
+++ b/rslp/large_scale_embeddings/predict_pipeline.py
@@ -3,9 +3,9 @@
 This computes 10 m/pixel, 128-dimensional, int8-quantized OlmoEarth embeddings over
 one tile (a part of a UTM zone) by creating PATCH_SIZE windows, materializing
 Sentinel-2 (and optionally Sentinel-1) mosaics from the OlmoEarth Datasets source,
-running the model, and uploading one GeoTIFF per window to out_path. A per-tile
-marker file is written to completed_path once the tile is done, recording which
-crops were written and which were skipped.
+running the model, and writing each window's embeddings into the GeoZarr store
+(see zarr_store.py). A per-tile marker file is written to completed_path once the
+tile is done, recording which crops were written and which were skipped.
 
 Windows that don't intersect the zone's canonical wedge or that are entirely ocean
 are skipped (see tiling.py). Embedding pixels where all Sentinel-2 mosaics are empty
@@ -16,7 +16,7 @@ multiples of PATCH_SIZE. The fixed 32768x32768 tiling lives only in write_jobs.p
 
 Note that different input variants (see EmbeddingInputs), checkpoints, and model
 settings (patch_size/window_size/overlap_size) produce different embeddings, so each
-combination must use its own out_path and completed_path.
+combination must use its own store and completed_path.
 """
 
 import json
@@ -51,6 +51,7 @@ from rslp.utils.rslearn import (
 
 from .model import NODATA_VALUE
 from .tiling import get_zone_wedge, list_kept_crops
+from .zarr_store import write_window_region
 
 logger = get_logger(__name__)
 
@@ -95,6 +96,13 @@ EMBEDDING_DIM = 128
 # etc.
 OUTPUT_BANDS = [f"B{band_idx}" for band_idx in range(EMBEDDING_DIM)]
 
+# These pool sizes are the long-standing default and are known to work. Scaling them
+# down to the job's window count was tried once and reverted, but on bad evidence (a
+# mismeasured elapsed time), so treat that as untested rather than disproven. If you
+# revisit it, note that materialize parallelizes over window x item-group units --
+# each window pulls 12 monthly mosaics, so a 12-window job is ~144 units, not 12 --
+# so sizing a pool by window count alone would under-parallelize. Measure completion
+# rate over several job durations before concluding anything.
 MATERIALIZE_PIPELINE_ARGS = MaterializePipelineArgs(
     disabled_layers=[],
     # Use initial job for prepare since it involves caching steps that should only be
@@ -197,7 +205,7 @@ def get_output_fname(
     Returns:
         the output filename.
     """
-    return UPath(out_path) / f"{str(projection.crs)}_{bounds[0]}_{bounds[1]}.tif"
+    return UPath(out_path) / f"{projection.crs!s}_{bounds[0]}_{bounds[1]}.tif"
 
 
 def get_marker_fname(
@@ -213,7 +221,7 @@ def get_marker_fname(
     Returns:
         the marker filename.
     """
-    return UPath(completed_path) / f"{str(projection.crs)}_{bounds[0]}_{bounds[1]}.json"
+    return UPath(completed_path) / f"{projection.crs!s}_{bounds[0]}_{bounds[1]}.json"
 
 
 def _crop_crosses_bad_longitude(projection: Projection, bounds: PixelBounds) -> bool:
@@ -242,30 +250,25 @@ def _crop_crosses_bad_longitude(projection: Projection, bounds: PixelBounds) -> 
     return False
 
 
-def _upload_window_output(
-    window: Window,
-    projection: Projection,
-    out_fname: UPath,
-    patch_size: int,
-) -> None:
-    """Upload one window's embedding raster to the output path.
+def _read_window_embeddings(window: Window, patch_size: int) -> np.ndarray:
+    """Read the window's int8 embedding raster and mask invalid pixels to nodata.
 
-    Reads the int8 embedding raster from the scratch dataset, sets pixels where all
-    Sentinel-2 mosaics are empty to NODATA_VALUE, and writes a tiled (uncompressed)
-    GeoTIFF to the output path.
+    Reads the merged embedding output from the scratch dataset and sets pixels where
+    all Sentinel-2 mosaics are empty to NODATA_VALUE.
 
     Args:
-        window: the window to upload.
-        projection: the UTM projection (must match the window projection).
-        out_fname: the output filename.
+        window: the window to read.
         patch_size: the encoder patch size. The embedding raster is at 1/patch_size
             of the window resolution.
+
+    Returns:
+        the int8 embedding array of shape (band, height, width).
     """
     # The embedding raster is at 1/patch_size of the window resolution.
     out_projection = Projection(
-        projection.crs,
-        projection.x_resolution * patch_size,
-        projection.y_resolution * patch_size,
+        window.projection.crs,
+        window.projection.x_resolution * patch_size,
+        window.projection.y_resolution * patch_size,
     )
     out_bounds = (
         window.bounds[0] // patch_size,
@@ -312,7 +315,34 @@ def _upload_window_output(
             patch_size,
         ).any(axis=(1, 3))
     embeddings[:, ~valid] = NODATA_VALUE
+    return embeddings
 
+
+def _write_debug_geotiff(
+    window: Window, embeddings: np.ndarray, debug_geotiff_path: str, patch_size: int
+) -> None:
+    """Write a window's embeddings to an uncompressed GeoTIFF for debugging.
+
+    Args:
+        window: the window being written.
+        embeddings: the int8 embedding array of shape (band, height, width).
+        debug_geotiff_path: the directory to write the GeoTIFF to.
+        patch_size: the encoder patch size; the embeddings are at 1/patch_size of the
+            window resolution, so the GeoTIFF is georeferenced at that resolution.
+    """
+    # The embedding raster is at 1/patch_size of the window resolution.
+    out_projection = Projection(
+        window.projection.crs,
+        window.projection.x_resolution * patch_size,
+        window.projection.y_resolution * patch_size,
+    )
+    out_bounds = (
+        window.bounds[0] // patch_size,
+        window.bounds[1] // patch_size,
+        window.bounds[2] // patch_size,
+        window.bounds[3] // patch_size,
+    )
+    out_fname = get_output_fname(debug_geotiff_path, window.projection, window.bounds)
     raster_format = GeotiffRasterFormat(
         always_enable_tiling=True,
         block_size=512,
@@ -330,22 +360,27 @@ def _upload_window_output(
     )
 
 
-def _upload_window_by_name(
+def _write_window_by_name(
     ds_path: UPath,
     window_name: str,
-    out_path: str,
+    store_path: str,
+    time_index: int,
     patch_size: int,
+    debug_geotiff_path: str | None,
 ) -> None:
-    """Load one window from the scratch dataset and upload its embedding raster.
+    """Load one window from the scratch dataset and write its embeddings to the store.
 
-    This is the multiprocessing worker for the upload step; the window is reloaded by
-    name so that only picklable arguments cross the process boundary.
+    This is the multiprocessing worker for the write step; the window is reloaded by
+    name so that only picklable arguments cross the process boundary. The window must
+    be in its zone's northern CRS (EPSG:326NN) so its bounds match the store grid.
 
     Args:
         ds_path: the scratch dataset path.
-        window_name: the name of the window to upload.
-        out_path: the output directory.
+        window_name: the name of the window to write.
+        store_path: the GeoZarr store path.
+        time_index: the index into the store's time axis for this reference year.
         patch_size: the encoder patch size.
+        debug_geotiff_path: if set, also write an uncompressed GeoTIFF here.
     """
     dataset = Dataset(ds_path)
     windows = dataset.load_windows(groups=[PREDICTION_GROUP], names=[window_name])
@@ -354,8 +389,18 @@ def _upload_window_by_name(
             f"expected one window named {window_name} but got {len(windows)}"
         )
     window = windows[0]
-    out_fname = get_output_fname(out_path, window.projection, window.bounds)
-    _upload_window_output(window, window.projection, out_fname, patch_size)
+    embeddings = _read_window_embeddings(window, patch_size)
+    zone_number = window.projection.crs.to_epsg() % 100
+    write_window_region(
+        store_path=store_path,
+        zone_number=zone_number,
+        window_bounds=window.bounds,
+        time_index=time_index,
+        embeddings=embeddings,
+        patch_size=patch_size,
+    )
+    if debug_geotiff_path is not None:
+        _write_debug_geotiff(window, embeddings, debug_geotiff_path, patch_size)
 
 
 def predict_pipeline(
@@ -363,34 +408,38 @@ def predict_pipeline(
     projection_json: str,
     bounds: PixelBounds,
     time_range: tuple[datetime, datetime],
-    out_path: str,
+    store_path: str,
     completed_path: str,
     checkpoint_path: str,
+    time_index: int,
     patch_size: int = 1,
     window_size: int = 16,
     overlap_size: int = 4,
     compile_model: bool = True,
     scratch_path: str | None = None,
     upload_workers: int = 16,
+    debug_geotiff_path: str | None = None,
 ) -> None:
     """Compute quantized OlmoEarth embeddings over one tile.
 
     Args:
         inputs: which input variant to use. Different variants produce different
-            embeddings so they must use different out_path/completed_path.
-        projection_json: JSON-encoded projection, normally a UTM zone with 10 m/pixel
-            resolution.
+            embeddings so they must use different stores.
+        projection_json: JSON-encoded projection, normally the zone's northern UTM CRS
+            (EPSG:326NN) with 10 m/pixel resolution.
         bounds: pixel coordinates within the projection on which to compute outputs.
             Each value must be a multiple of PATCH_SIZE.
         time_range: the reference timestamp as (T, T). The layer time_offset/duration
             derive the twelve monthly mosaics over the following year from this.
-        out_path: directory to write one embedding GeoTIFF per PATCH_SIZE crop.
+        store_path: the GeoZarr store to write embeddings into (must be initialized
+            by init_store first).
         completed_path: directory to write per-tile completion markers.
         checkpoint_path: the OlmoEarth checkpoint to compute embeddings with, e.g.
             /weka/dfive-default/helios/checkpoints/gabrielt/regbtl_v1_2_gdyn_d128_wideread_regsup_latlon_w0p1/step560000.
             Different checkpoints produce different embeddings so they must use
-            different out_path/completed_path (same for patch_size, window_size, and
+            different store and completed_path (same for patch_size, window_size, and
             overlap_size below).
+        time_index: the index into the store's time axis for this reference year.
         patch_size: the encoder patch size; yields one 128-dimensional embedding per
             patch_size x patch_size pixels (so the output rasters are at 1/patch_size
             of the window resolution).
@@ -403,8 +452,10 @@ def predict_pipeline(
         scratch_path: optional directory to store the scratch rslearn dataset in
             directly, and keep it afterward (useful for debugging). By default, a
             temporary directory is used and deleted when the tile is done.
-        upload_workers: number of worker processes for uploading the per-crop
-            embedding GeoTIFFs.
+        upload_workers: number of worker processes for writing the per-crop
+            embeddings.
+        debug_geotiff_path: if set, also write an uncompressed GeoTIFF per crop here
+            (for debugging small runs).
     """
     if PATCH_SIZE % patch_size != 0:
         raise ValueError(f"patch_size must divide {PATCH_SIZE}, got {patch_size}")
@@ -433,15 +484,17 @@ def predict_pipeline(
                 projection=projection,
                 bounds=bounds,
                 time_range=time_range,
-                out_path=out_path,
+                store_path=store_path,
                 marker_fname=marker_fname,
                 ds_path=UPath(tmp_dir) / "dataset",
                 checkpoint_path=checkpoint_path,
+                time_index=time_index,
                 patch_size=patch_size,
                 window_size=window_size,
                 overlap_size=overlap_size,
                 compile_model=compile_model,
                 upload_workers=upload_workers,
+                debug_geotiff_path=debug_geotiff_path,
             )
     else:
         _process_tile(
@@ -449,15 +502,17 @@ def predict_pipeline(
             projection=projection,
             bounds=bounds,
             time_range=time_range,
-            out_path=out_path,
+            store_path=store_path,
             marker_fname=marker_fname,
             ds_path=UPath(scratch_path),
             checkpoint_path=checkpoint_path,
+            time_index=time_index,
             patch_size=patch_size,
             window_size=window_size,
             overlap_size=overlap_size,
             compile_model=compile_model,
             upload_workers=upload_workers,
+            debug_geotiff_path=debug_geotiff_path,
         )
 
 
@@ -466,15 +521,17 @@ def _process_tile(
     projection: Projection,
     bounds: PixelBounds,
     time_range: tuple[datetime, datetime],
-    out_path: str,
+    store_path: str,
     marker_fname: UPath,
     ds_path: UPath,
     checkpoint_path: str,
+    time_index: int,
     patch_size: int,
     window_size: int,
     overlap_size: int,
     compile_model: bool,
     upload_workers: int,
+    debug_geotiff_path: str | None,
 ) -> None:
     """Process one tile using the given scratch dataset path.
 
@@ -485,16 +542,18 @@ def _process_tile(
         projection: the projection of the tile.
         bounds: the pixel bounds of the tile.
         time_range: the reference timestamp as (T, T).
-        out_path: directory to write one embedding GeoTIFF per PATCH_SIZE crop.
+        store_path: the GeoZarr store to write embeddings into.
         marker_fname: the per-tile completion marker filename to write.
         ds_path: where to create the temporary rslearn dataset.
         checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
+        time_index: the index into the store's time axis for this reference year.
         patch_size: the encoder patch size.
         window_size: the size of the crops the model operates on.
         overlap_size: overlap in pixels between adjacent crops.
         compile_model: whether to compile the encoder transformer blocks.
-        upload_workers: number of worker processes for uploading the per-crop
-            embedding GeoTIFFs.
+        upload_workers: number of worker processes for writing the per-crop
+            embeddings.
+        debug_geotiff_path: if set, also write an uncompressed GeoTIFF per crop here.
     """
     # Initialize an rslearn dataset in scratch from the predict dataset config.
     dataset_config_fname = DATASET_CONFIG_FNAME.format(inputs=inputs.value)
@@ -562,9 +621,9 @@ def _process_tile(
                 ),
             )
 
-        # Upload each window's embedding raster. The uploads are handled by a pool
-        # of worker processes since converting and uploading the rasters is slow. We
-        # use the forkserver context because the CUDA context initialized by
+        # Write each window's embeddings to the store. The writes are handled by a
+        # pool of worker processes since converting and writing the rasters is slow.
+        # We use the forkserver context because the CUDA context initialized by
         # run_model_predict above cannot be safely forked.
         upload_kwargs: list[dict] = []
         for window in windows:
@@ -578,8 +637,10 @@ def _process_tile(
                 dict(
                     ds_path=ds_path,
                     window_name=window.name,
-                    out_path=out_path,
+                    store_path=store_path,
+                    time_index=time_index,
                     patch_size=patch_size,
+                    debug_geotiff_path=debug_geotiff_path,
                 )
             )
             written.append(crop_offset)
@@ -587,7 +648,7 @@ def _process_tile(
             pool = multiprocessing.get_context("forkserver").Pool(upload_workers)
             try:
                 for _ in star_imap_unordered(
-                    pool, _upload_window_by_name, upload_kwargs
+                    pool, _write_window_by_name, upload_kwargs
                 ):
                     pass
             finally:
@@ -606,6 +667,7 @@ def _process_tile(
         "projection": projection.serialize(),
         "bounds": list(bounds),
         "time_range": [time_range[0].isoformat(), time_range[1].isoformat()],
+        "time_index": time_index,
         "written": written,
         "skipped_no_data": skipped_no_data,
         "skipped_longitude": skipped_longitude,

--- a/rslp/large_scale_embeddings/supervise.py
+++ b/rslp/large_scale_embeddings/supervise.py
@@ -35,6 +35,7 @@ import multiprocessing
 import random
 import time
 from datetime import UTC, datetime
+from multiprocessing.sharedctypes import Synchronized
 from typing import Any
 
 from rslp.log_utils import get_logger
@@ -62,7 +63,9 @@ DEFAULT_WEKA_MOUNT_PATH = "/weka/dfive-default"
 # The OlmoEarth Datasets data source needs an endpoint plus a bearer token, the latter
 # read from a Beaker secret of this name in the target workspace.
 DEFAULT_DATASETS_API_URL = "https://datasets.olmoearth.allenai.org"
-DEFAULT_DATASETS_TOKEN_SECRET = "LCC_DATASETS_API_TOKEN"
+# This is the name of a Beaker secret, not a credential. (bandit flags the assignment
+# because the name contains "token"/"secret".)
+DEFAULT_DATASETS_TOKEN_SECRET = "LCC_DATASETS_API_TOKEN"  # nosec
 
 
 def _state_name(entry: Any) -> str:
@@ -354,7 +357,9 @@ def supervise(
 
     while max_cycles is None or cycle < max_cycles:
         cycle += 1
-        result = ctx.Value("i", _NO_RESULT)
+        # Typeshed types Value() as SynchronizedBase, which has no .value; the "i"
+        # type code makes it a Synchronized[int].
+        result: Synchronized[int] = ctx.Value("i", _NO_RESULT)  # type: ignore[assignment]
         proc = ctx.Process(target=_run_cycle, args=(kwargs, result))
         started = time.time()
         proc.start()

--- a/rslp/large_scale_embeddings/supervise.py
+++ b/rslp/large_scale_embeddings/supervise.py
@@ -1,0 +1,407 @@
+"""Keep an embedding run making progress on preemptible workers.
+
+Workers are preemptible and the GPU clusters are routinely saturated, so a long run
+loses workers constantly. Two existing properties make that survivable:
+
+1. Every job is idempotent -- ``predict_pipeline`` returns immediately when the tile's
+   completion marker already exists -- so re-enqueuing work is cheap and safe.
+2. ``get_jobs`` derives the remaining work from those markers, so "what is left" never
+   has to be tracked separately.
+
+Two design points, both learned the hard way:
+
+**Keep the queue shallow.** A Beaker queue entry claimed by a worker that then dies is
+not released back to the queue. Entries were still CLAIMED 5 hours after being claimed,
+with no worker alive for the last 1.4 of those, and the queue API has no call to release
+one. They are not immortal -- ``status.expiry`` is set from ``expires_in_sec`` (7 days
+by default), so they eventually age out -- but a week is far longer than any job, so
+within a run that work is simply lost. Note also ``max_claimed_entries=1``: a dead
+worker's claim permanently occupies that entry's only claim slot. (``wait_timeout`` on
+the queue is unrelated; it bounds how long a worker waits for work to appear.)
+
+Enqueuing a whole run up front therefore bleeds work steadily (one run accumulated 327
+orphaned entries). This enqueues only a small buffer and refills it from the markers,
+which bounds the loss to about one entry per worker death.
+
+**Run each cycle in a child process.** The Beaker client has no RPC timeout, and a
+hung gRPC call cannot be interrupted by ``signal.alarm`` because the C core does not
+yield to the interpreter between bytecodes. An in-process watchdog therefore does not
+work -- two earlier attempts silently stalled for ~10 hours each, which stopped both
+queue refills and worker top-up. Only a process-level kill bounds it, so every cycle
+runs in a spawned child that the parent will terminate if it overruns its budget.
+"""
+
+import multiprocessing
+import random
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from rslp.log_utils import get_logger
+
+from .predict_pipeline import EmbeddingInputs
+
+logger = get_logger(__name__)
+
+# Pending entries to keep per worker: enough that no worker idles waiting for work,
+# few enough that entries orphaned by dying workers stay a rounding error.
+PENDING_PER_WORKER = 3
+
+# A cycle that outruns this is assumed wedged (almost always a hung Beaker RPC) and
+# gets killed. Cycles normally take well under a minute.
+DEFAULT_CYCLE_BUDGET_SECONDS = 600
+
+# Sentinel for "the child did not report a result" (timed out, crashed, or killed).
+_NO_RESULT = -1
+
+# Deployment defaults, collected here rather than buried in the signatures below so a
+# different environment only has to change one place (or override them per call).
+# The checkpoint lives on WEKA, so workers need it mounted.
+DEFAULT_WEKA_BUCKET = "dfive-default"
+DEFAULT_WEKA_MOUNT_PATH = "/weka/dfive-default"
+# The OlmoEarth Datasets data source needs an endpoint plus a bearer token, the latter
+# read from a Beaker secret of this name in the target workspace.
+DEFAULT_DATASETS_API_URL = "https://datasets.olmoearth.allenai.org"
+DEFAULT_DATASETS_TOKEN_SECRET = "LCC_DATASETS_API_TOKEN"
+
+
+def _state_name(entry: Any) -> str:
+    """Get the state enum name for a queue entry (PENDING/CLAIMED/COMPLETED)."""
+    status = entry.status
+    try:
+        return (
+            status.DESCRIPTOR.fields_by_name["state"]
+            .enum_type.values_by_number[int(status.state)]
+            .name.split("_")[-1]
+        )
+    except (KeyError, ValueError):
+        return "UNKNOWN"
+
+
+def _run_cycle(kwargs: dict[str, Any], result: Any) -> None:
+    """Run one supervision cycle, reporting the remaining job count via `result`.
+
+    This runs in a child process so the parent can kill it if a Beaker RPC hangs. It
+    sets `result.value` to the number of jobs still lacking a completion marker, or
+    leaves it at `_NO_RESULT` if it does not get that far.
+
+    Args:
+        kwargs: the supervise() arguments this cycle needs.
+        result: shared int the remaining-job count is written to.
+    """
+    from beaker import Beaker, BeakerJobPriority
+
+    import rslp.common.worker
+    from rslp.utils.beaker import DEFAULT_WORKSPACE, WekaMount
+
+    from .write_jobs import get_jobs
+
+    queue_name = kwargs["queue_name"]
+    num_workers = kwargs["num_workers"]
+    target_pending = num_workers * PENDING_PER_WORKER
+
+    with Beaker.from_env(default_workspace=DEFAULT_WORKSPACE) as beaker:
+        queue = beaker.queue.get(queue_name)
+        counts: dict[str, int] = {}
+        for entry in beaker.queue.list_entries(queue):
+            name = _state_name(entry)
+            counts[name] = counts.get(name, 0) + 1
+        now = time.time()
+        live = sum(
+            1
+            for worker in beaker.queue.list_workers(queue)
+            if now - int(getattr(getattr(worker, "heartbeat", None), "seconds", 0) or 0)
+            < kwargs["stale_seconds"]
+        )
+    pending = counts.get("PENDING", 0)
+    logger.info("queue=%s live_workers=%d", counts, live)
+
+    # Recompute what is left directly from the completion markers. This doubles as the
+    # completion check, so it runs every cycle rather than only when the queue drains.
+    years = kwargs["years"]
+    remaining: list[list[str]] = []
+    for year in years:
+        remaining.extend(
+            get_jobs(
+                inputs=kwargs["inputs"],
+                timestamp=datetime(year, 1, 1, tzinfo=UTC),
+                store_path=kwargs["store_path"],
+                completed_path=kwargs["completed_path_template"].format(year=year),
+                checkpoint_path=kwargs["checkpoint_path"],
+                time_index=years.index(year),
+                patch_size=kwargs["patch_size"],
+                window_size=kwargs["window_size"],
+                overlap_size=kwargs["overlap_size"],
+                compile_model=kwargs["compile_model"],
+                epsg_code=kwargs["epsg_code"],
+                wgs84_bounds=kwargs["wgs84_bounds"],
+                geojson_fname=kwargs["geojson_fname"],
+                job_size=kwargs["job_size"],
+            )
+        )
+    result.value = len(remaining)
+    logger.info("%d job(s) still without a completion marker", len(remaining))
+    if not remaining:
+        return
+
+    # Top the queue up only when it is shallow, so duplicate work and orphaned
+    # entries both stay bounded.
+    if pending < target_pending:
+        random.shuffle(remaining)
+        batch = remaining[: target_pending - pending]
+        rslp.common.worker.write_jobs(
+            queue_name, "large_scale_embeddings", "predict", batch
+        )
+        logger.info("enqueued %d job(s) (pending was %d)", len(batch), pending)
+
+    if live < num_workers:
+        rslp.common.worker.launch_workers(
+            image_name=kwargs["image_name"],
+            queue_name=queue_name,
+            num_workers=num_workers - live,
+            cluster=kwargs["cluster"],
+            gpus=kwargs["gpus"],
+            shared_memory=kwargs["shared_memory"],
+            priority=BeakerJobPriority[kwargs["priority"]],
+            weka_mounts=[
+                WekaMount(
+                    bucket_name=kwargs["weka_bucket"],
+                    mount_path=kwargs["weka_mount_path"],
+                )
+            ],
+            extra_env_vars={"OEDATASETS_API_URL": kwargs["datasets_api_url"]},
+            extra_env_secrets={"DATASETS_API_TOKEN": kwargs["datasets_token_secret"]},
+        )
+        logger.info("launched %d worker(s)", num_workers - live)
+
+
+def launch_supervisor(
+    image_name: str,
+    cluster: list[str],
+    supervise_args: list[str],
+    priority: str = "high",
+    task_name: str = "geozarr-supervisor",
+    cpu_count: float = 2,
+    memory: str = "8GiB",
+    gpu_count: int = 0,
+    preemptible: bool = False,
+) -> str:
+    """Launch `supervise` as a CPU-only Beaker job so a run outlives any one session.
+
+    The supervisor must not depend on a workstation: it needs to keep refilling the
+    queue and the worker pool for the whole run. It needs no GPU. The base env vars
+    already supply BEAKER_TOKEN (to manage the queue and launch workers) and
+    GOOGLE_APPLICATION_CREDENTIALS (to read completion markers), so no extra wiring
+    is required.
+
+    Args:
+        image_name: the Beaker image to run (must contain this workflow).
+        cluster: clusters to schedule on; a CPU cluster is appropriate.
+        supervise_args: arguments forwarded verbatim to the `supervise` workflow, e.g.
+            ["--inputs", "S2", "--years", "[2024, 2025]", ...]. Passed through rather
+            than re-declared so this launcher never drifts from supervise()'s options.
+        priority: Beaker priority. Losing the supervisor stalls the whole run, so
+            prefer a priority that will not be evicted.
+        task_name: name for the Beaker experiment.
+        cpu_count: CPUs to request.
+        memory: memory to request.
+        gpu_count: GPUs to request. The supervisor needs none, but on saturated
+            GPU clusters a 0-GPU task may never be scheduled (slots are counted
+            in GPUs), so requesting 1 is sometimes the only way to place it
+            alongside the workers. Wasteful; prefer 0 where it schedules.
+        preemptible: whether the supervisor itself may be preempted. Defaults to
+            False; the supervisor is cheap and losing it stops all progress.
+
+    Returns:
+        the created Beaker experiment's ID.
+    """
+    from beaker import (
+        Beaker,
+        BeakerConstraints,
+        BeakerExperimentSpec,
+        BeakerJobPriority,
+        BeakerTaskResources,
+    )
+
+    from rslp.utils.beaker import (
+        DEFAULT_BUDGET,
+        DEFAULT_WORKSPACE,
+        create_gcp_credentials_mount,
+        get_base_env_vars,
+    )
+
+    spec = BeakerExperimentSpec.new(
+        budget=DEFAULT_BUDGET,
+        description="large_scale_embeddings supervisor",
+        beaker_image=image_name,
+        priority=BeakerJobPriority[priority],
+        command=["python", "-m", "rslp.main"],
+        arguments=["large_scale_embeddings", "supervise", *supervise_args],
+        constraints=BeakerConstraints(cluster=cluster),
+        preemptible=preemptible,
+        datasets=[create_gcp_credentials_mount()],
+        env_vars=get_base_env_vars(),
+        resources=BeakerTaskResources(
+            cpu_count=cpu_count, memory=memory, gpu_count=gpu_count
+        ),
+    )
+    with Beaker.from_env(default_workspace=DEFAULT_WORKSPACE) as beaker:
+        workload = beaker.experiment.create(name=task_name, spec=spec)
+    experiment_id = getattr(workload, "id", None) or str(workload)
+    logger.info("launched supervisor experiment %s on %s", experiment_id, cluster)
+    return experiment_id
+
+
+def supervise(
+    inputs: EmbeddingInputs,
+    years: list[int],
+    store_path: str,
+    completed_path_template: str,
+    queue_name: str,
+    checkpoint_path: str,
+    image_name: str,
+    cluster: list[str],
+    weka_bucket: str = DEFAULT_WEKA_BUCKET,
+    weka_mount_path: str = DEFAULT_WEKA_MOUNT_PATH,
+    datasets_api_url: str = DEFAULT_DATASETS_API_URL,
+    datasets_token_secret: str = DEFAULT_DATASETS_TOKEN_SECRET,
+    num_workers: int = 8,
+    gpus: int = 1,
+    job_size: int = 8192,
+    patch_size: int = 1,
+    window_size: int = 16,
+    overlap_size: int = 4,
+    compile_model: bool = True,
+    priority: str = "high",
+    shared_memory: str = "256GiB",
+    geojson_fname: str | None = None,
+    epsg_code: int | None = None,
+    wgs84_bounds: tuple[float, float, float, float] | None = None,
+    cycle_seconds: int = 900,
+    stale_seconds: int = 900,
+    cycle_budget_seconds: int = DEFAULT_CYCLE_BUDGET_SECONDS,
+    max_cycles: int | None = None,
+) -> None:
+    """Refill the queue and worker pool each cycle until every tile has a marker.
+
+    Args:
+        inputs: which input variant to use.
+        years: the reference years to produce; each becomes a (T, T) timestamp. The
+            order must match the store's time axis.
+        store_path: the GeoZarr store to write into (must already be initialized).
+        completed_path_template: marker directory containing a ``{year}``
+            placeholder, e.g. ``gs://bucket/prefix/s2_{year}_completed/``.
+        queue_name: the Beaker queue to keep topped up.
+        checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
+        image_name: the Beaker image the workers run.
+        cluster: Beaker clusters to schedule workers on.
+        weka_bucket: WEKA bucket to mount (the checkpoint lives there).
+        weka_mount_path: where to mount it.
+        datasets_api_url: OlmoEarth Datasets API URL for the data source.
+        datasets_token_secret: Beaker secret holding the datasets bearer token.
+        num_workers: how many workers to keep alive.
+        gpus: GPUs to request per worker. Raising this reduces how many workers share
+            a node, which is worth trying if workers are dying to memory pressure.
+        job_size: pixel size of each job. Must be small enough that a job finishes
+            inside the typical gap between preemptions (see the README).
+        patch_size: the encoder patch size.
+        window_size: the size of the crops the model operates on.
+        overlap_size: overlap in pixels between adjacent crops.
+        compile_model: whether to compile the encoder transformer blocks.
+        priority: Beaker priority for the workers.
+        shared_memory: shared memory to request per worker.
+        geojson_fname: limit work to tiles intersecting this WGS84 GeoJSON file.
+        epsg_code: limit work to the zone of this UTM EPSG code.
+        wgs84_bounds: limit work to tiles intersecting these WGS84 bounds.
+        cycle_seconds: how long to sleep between cycles.
+        stale_seconds: a worker with no heartbeat for this long counts as dead.
+        cycle_budget_seconds: kill a cycle that runs longer than this.
+        max_cycles: stop after this many cycles; None runs until the work is done.
+    """
+    kwargs: dict[str, Any] = {
+        "inputs": inputs,
+        "years": years,
+        "store_path": store_path,
+        "completed_path_template": completed_path_template,
+        "queue_name": queue_name,
+        "checkpoint_path": checkpoint_path,
+        "image_name": image_name,
+        "cluster": cluster,
+        "weka_bucket": weka_bucket,
+        "weka_mount_path": weka_mount_path,
+        "datasets_api_url": datasets_api_url,
+        "datasets_token_secret": datasets_token_secret,
+        "num_workers": num_workers,
+        "gpus": gpus,
+        "job_size": job_size,
+        "patch_size": patch_size,
+        "window_size": window_size,
+        "overlap_size": overlap_size,
+        "compile_model": compile_model,
+        "priority": priority,
+        "shared_memory": shared_memory,
+        "geojson_fname": geojson_fname,
+        "epsg_code": epsg_code,
+        "wgs84_bounds": wgs84_bounds,
+        "stale_seconds": stale_seconds,
+    }
+
+    # "spawn" rather than the default fork: the child creates gRPC channels, and
+    # forking a process that may already hold them is a known source of hangs.
+    ctx = multiprocessing.get_context("spawn")
+    seen_work = False
+    cycle = 0
+
+    while max_cycles is None or cycle < max_cycles:
+        cycle += 1
+        result = ctx.Value("i", _NO_RESULT)
+        proc = ctx.Process(target=_run_cycle, args=(kwargs, result))
+        started = time.time()
+        proc.start()
+        proc.join(cycle_budget_seconds)
+        if proc.is_alive():
+            logger.warning(
+                "cycle %d exceeded its %ds budget; killing it (likely a hung Beaker "
+                "RPC) and continuing",
+                cycle,
+                cycle_budget_seconds,
+            )
+            proc.terminate()
+            proc.join(30)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(30)
+        elapsed = int(time.time() - started)
+        remaining = result.value
+
+        if remaining == _NO_RESULT:
+            # Killed, crashed, or otherwise did not report. Nothing to conclude about
+            # the run's state, so just try again next cycle.
+            logger.warning(
+                "cycle %d did not report a result after %ds (exit code %s); retrying",
+                cycle,
+                elapsed,
+                proc.exitcode,
+            )
+        elif remaining == 0:
+            if not seen_work:
+                # Enumerating nothing on the very first cycle almost never means "the
+                # run is finished" -- far more often the AOI filters, bounds, or zone
+                # selection exclude everything. Fail loudly rather than reporting a
+                # successful no-op run.
+                raise ValueError(
+                    "enumerated no jobs at all on the first cycle; check "
+                    "geojson_fname/wgs84_bounds/epsg_code and that store_path and "
+                    "completed_path_template are correct"
+                )
+            logger.info("all tiles have completion markers; run complete")
+            return
+        else:
+            seen_work = True
+            logger.info(
+                "cycle %d done in %ds; %d job(s) remaining", cycle, elapsed, remaining
+            )
+
+        time.sleep(cycle_seconds)
+
+    logger.info("reached max_cycles=%d; exiting", cycle)

--- a/rslp/large_scale_embeddings/tiling.py
+++ b/rslp/large_scale_embeddings/tiling.py
@@ -1,0 +1,162 @@
+"""Tiling helpers for global embedding inference.
+
+The world is processed as TILE_SIZE tiles in each UTM zone (see write_jobs.py), and
+each tile is processed as PATCH_SIZE crops (see predict_pipeline.py). Tiles are
+enumerated from the bounding box of each zone's projected extent, so without
+filtering there is substantial duplication across zones (each point on land would be
+computed in ~2.2 zones on average). This module provides the filters that reduce the
+duplication to ~1.04x:
+
+- Zone wedge: each UTM zone has a canonical 6-degree longitude wedge (0 to 84N for
+  northern zones, 80S to 0 for southern zones). We only keep tiles and crops that
+  intersect their own zone's wedge, so areas covered by multiple zones' projected
+  extents are only processed in the zone that owns them.
+- Ocean: we skip crops whose four corners are all ocean according to the
+  global_land_mask package.
+"""
+
+import functools
+
+import numpy as np
+import shapely
+from global_land_mask import globe
+from pyproj import Transformer
+from rasterio.crs import CRS
+from rslearn.utils.geometry import PixelBounds, Projection
+from rslearn.utils.get_utm_ups_crs import get_wgs84_bounds
+
+# Number of vertices to use when densifying the wedge meridian (north-south) and
+# parallel (east-west) edges. The meridian edges are curved in projected coordinates
+# so they need dense sampling.
+NUM_MERIDIAN_VERTICES = 4096
+NUM_PARALLEL_VERTICES = 256
+
+
+@functools.cache
+def _get_zone_wedge(epsg_code: int, resolution: float) -> shapely.Polygon:
+    """Cached implementation of get_zone_wedge keyed on the EPSG code."""
+    utm_zone = CRS.from_epsg(epsg_code)
+    min_lon, min_lat, max_lon, max_lat = get_wgs84_bounds(utm_zone)
+    transformer = Transformer.from_crs("EPSG:4326", f"EPSG:{epsg_code}", always_xy=True)
+    lons = np.concatenate(
+        [
+            np.linspace(min_lon, max_lon, NUM_PARALLEL_VERTICES),
+            np.full(NUM_MERIDIAN_VERTICES, max_lon),
+            np.linspace(max_lon, min_lon, NUM_PARALLEL_VERTICES),
+            np.full(NUM_MERIDIAN_VERTICES, min_lon),
+        ]
+    )
+    lats = np.concatenate(
+        [
+            np.full(NUM_PARALLEL_VERTICES, min_lat),
+            np.linspace(min_lat, max_lat, NUM_MERIDIAN_VERTICES),
+            np.full(NUM_PARALLEL_VERTICES, max_lat),
+            np.linspace(max_lat, min_lat, NUM_MERIDIAN_VERTICES),
+        ]
+    )
+    xs, ys = transformer.transform(lons, lats)
+    # Convert projected meters to pixel coordinates. The pixel y axis points south
+    # (y_resolution is -resolution).
+    wedge = shapely.Polygon(
+        np.stack([np.array(xs) / resolution, -np.array(ys) / resolution], axis=1)
+    )
+    shapely.prepare(wedge)
+    return wedge
+
+
+def get_zone_wedge(utm_zone: CRS, resolution: float) -> shapely.Polygon:
+    """Get the canonical wedge of a UTM zone as a polygon in pixel coordinates.
+
+    Args:
+        utm_zone: the CRS which must correspond to a UTM EPSG.
+        resolution: the projection resolution in m/pixel (the y resolution is assumed
+            to be its negation).
+
+    Returns:
+        the wedge polygon in pixel coordinates, prepared for fast intersection tests.
+    """
+    return _get_zone_wedge(utm_zone.to_epsg(), resolution)
+
+
+@functools.cache
+def _get_to_wgs84_transformer(epsg_code: int) -> Transformer:
+    """Get a cached transformer from the given EPSG code to WGS84."""
+    return Transformer.from_crs(f"EPSG:{epsg_code}", "EPSG:4326", always_xy=True)
+
+
+def bounds_intersect_wedge(wedge: shapely.Polygon, bounds: PixelBounds) -> bool:
+    """Check whether the given pixel bounds intersect the zone wedge.
+
+    Args:
+        wedge: the zone wedge from get_zone_wedge (in matching pixel coordinates).
+        bounds: the pixel bounds to check.
+
+    Returns:
+        whether the bounds intersect the wedge.
+    """
+    return wedge.intersects(shapely.box(*bounds))
+
+
+def list_kept_crops(
+    projection: Projection,
+    bounds: PixelBounds,
+    crop_size: int,
+    wedge: shapely.Polygon | None = None,
+) -> list[PixelBounds]:
+    """List the crops within the given bounds that should be processed.
+
+    The bounds are divided into a grid of crop_size x crop_size crops. A crop is kept
+    if it intersects the zone's canonical wedge, and at least one of its four corners
+    is land according to global_land_mask.
+
+    Args:
+        projection: the UTM projection (with negative y resolution).
+        bounds: the pixel bounds to divide into crops. Each value must be a multiple
+            of crop_size.
+        crop_size: the size of each crop in pixels.
+        wedge: the zone wedge from get_zone_wedge; computed if not provided.
+
+    Returns:
+        list of pixel bounds of the crops to process.
+    """
+    for value in bounds:
+        assert value % crop_size == 0
+    if wedge is None:
+        wedge = get_zone_wedge(projection.crs, projection.x_resolution)
+
+    cols = list(range(bounds[0] // crop_size, bounds[2] // crop_size))
+    rows = list(range(bounds[1] // crop_size, bounds[3] // crop_size))
+
+    # Compute the land mask at the lattice of crop corners, in one vectorized pass.
+    corner_xs_px = np.array([col * crop_size for col in cols] + [bounds[2]])
+    corner_ys_px = np.array([row * crop_size for row in rows] + [bounds[3]])
+    xs_m, ys_m = np.meshgrid(
+        corner_xs_px * projection.x_resolution,
+        corner_ys_px * projection.y_resolution,
+    )
+    transformer = _get_to_wgs84_transformer(projection.crs.to_epsg())
+    lons, lats = transformer.transform(xs_m, ys_m)
+    # Wrap/clip into the domain expected by global_land_mask.
+    lons = ((np.array(lons) + 180) % 360) - 180
+    lats = np.clip(np.array(lats), -89.99, 89.99)
+    # is_land is indexed [row, col] following the meshgrid above.
+    is_land = globe.is_land(lats, lons)
+
+    kept: list[PixelBounds] = []
+    for row_idx, row in enumerate(rows):
+        for col_idx, col in enumerate(cols):
+            # Skip if all four corners of the crop are ocean.
+            if not is_land[row_idx : row_idx + 2, col_idx : col_idx + 2].any():
+                continue
+            crop_bounds = (
+                col * crop_size,
+                row * crop_size,
+                (col + 1) * crop_size,
+                (row + 1) * crop_size,
+            )
+            # Skip if the crop does not intersect the canonical zone wedge (it will be
+            # processed by the neighboring UTM zone instead).
+            if not bounds_intersect_wedge(wedge, crop_bounds):
+                continue
+            kept.append(crop_bounds)
+    return kept

--- a/rslp/large_scale_embeddings/tiling.py
+++ b/rslp/large_scale_embeddings/tiling.py
@@ -1,21 +1,24 @@
 """Tiling helpers for global embedding inference.
 
-The world is processed as TILE_SIZE tiles in each UTM zone (see write_jobs.py), and
-each tile is processed as PATCH_SIZE crops (see predict_pipeline.py). Tiles are
-enumerated from the bounding box of each zone's projected extent, so without
-filtering there is substantial duplication across zones (each point on land would be
-computed in ~2.2 zones on average). This module provides the filters that reduce the
-duplication to ~1.04x:
+The world is processed one UTM zone number (1-60) at a time. Each zone is handled in
+its northern CRS (EPSG:326NN) with a continuous northing axis that goes negative
+south of the equator, so a single zone covers both hemispheres (matching the geoemb
+utm_zones layout). Each zone is divided into TILE_SIZE tiles (see write_jobs.py), and
+each tile into PATCH_SIZE crops (see predict_pipeline.py). Tiles are enumerated from
+the zone's projected extent, so without filtering there is substantial duplication
+across zones (each point on land would be computed in ~2.2 zones on average). This
+module provides the filters that reduce the duplication to ~1.04x:
 
-- Zone wedge: each UTM zone has a canonical 6-degree longitude wedge (0 to 84N for
-  northern zones, 80S to 0 for southern zones). We only keep tiles and crops that
-  intersect their own zone's wedge, so areas covered by multiple zones' projected
-  extents are only processed in the zone that owns them.
+- Zone wedge: each UTM zone has a canonical 6-degree longitude wedge spanning the
+  full UTM latitude range (80S to 84N). We only keep tiles and crops that intersect
+  their own zone's wedge, so areas covered by multiple zones' projected extents are
+  only processed in the zone that owns them.
 - Ocean: we skip crops whose four corners are all ocean according to the
   global_land_mask package.
 """
 
 import functools
+import math
 
 import numpy as np
 import shapely
@@ -31,12 +34,22 @@ from rslearn.utils.get_utm_ups_crs import get_wgs84_bounds
 NUM_MERIDIAN_VERTICES = 4096
 NUM_PARALLEL_VERTICES = 256
 
+# EPSG code base for northern-hemisphere WGS84 UTM zones (326NN).
+NORTH_EPSG_BASE = 32600
+# Latitude range covered by UTM (80S to 84N). Each zone wedge spans this full range
+# in its northern CRS so one zone group covers both hemispheres.
+UTM_MIN_LAT = -80.0
+UTM_MAX_LAT = 84.0
+
 
 @functools.cache
 def _get_zone_wedge(epsg_code: int, resolution: float) -> shapely.Polygon:
     """Cached implementation of get_zone_wedge keyed on the EPSG code."""
     utm_zone = CRS.from_epsg(epsg_code)
-    min_lon, min_lat, max_lon, max_lat = get_wgs84_bounds(utm_zone)
+    # Use the zone's canonical 6-degree longitude band but span the full UTM latitude
+    # range so a single northern-CRS wedge covers both hemispheres (see module docs).
+    min_lon, _, max_lon, _ = get_wgs84_bounds(utm_zone)
+    min_lat, max_lat = UTM_MIN_LAT, UTM_MAX_LAT
     transformer = Transformer.from_crs("EPSG:4326", f"EPSG:{epsg_code}", always_xy=True)
     lons = np.concatenate(
         [
@@ -76,6 +89,44 @@ def get_zone_wedge(utm_zone: CRS, resolution: float) -> shapely.Polygon:
         the wedge polygon in pixel coordinates, prepared for fast intersection tests.
     """
     return _get_zone_wedge(utm_zone.to_epsg(), resolution)
+
+
+def get_zone_grid(
+    zone_number: int,
+    resolution: float,
+    tile_size: int,
+) -> tuple[Projection, tuple[int, int], tuple[int, int]]:
+    """Get the northern-CRS pixel grid for a UTM zone number spanning both hemispheres.
+
+    The zone is processed once, in its northern CRS (EPSG:326NN), with a continuous
+    northing axis that goes negative south of the equator so a single grid covers
+    both hemispheres. The array origin and shape are snapped outward to a multiple of
+    tile_size (itself a multiple of PATCH_SIZE) so tiles, crops, and zarr shards stay
+    aligned. This is the single source of truth for the per-zone grid, used by both
+    the job enumeration (write_jobs.py) and the zarr store init (zarr_store.py).
+
+    Args:
+        zone_number: the UTM zone number (1-60).
+        resolution: the projection resolution in m/pixel.
+        tile_size: the tile size in pixels; the origin and shape are snapped outward
+            to a multiple of this.
+
+    Returns:
+        a tuple (projection, origin_px, shape_px) where projection is the northern
+        UTM projection, origin_px is the (x, y) pixel coordinate of the array's
+        top-left corner, and shape_px is the (height, width) of the array in pixels.
+    """
+    utm_zone = CRS.from_epsg(NORTH_EPSG_BASE + zone_number)
+    projection = Projection(utm_zone, resolution, -resolution)
+    wedge = get_zone_wedge(utm_zone, resolution)
+    min_x, min_y, max_x, max_y = wedge.bounds
+    origin_x = math.floor(min_x / tile_size) * tile_size
+    origin_y = math.floor(min_y / tile_size) * tile_size
+    end_x = math.ceil(max_x / tile_size) * tile_size
+    end_y = math.ceil(max_y / tile_size) * tile_size
+    origin_px = (origin_x, origin_y)
+    shape_px = (end_y - origin_y, end_x - origin_x)
+    return projection, origin_px, shape_px
 
 
 @functools.cache

--- a/rslp/large_scale_embeddings/write_jobs.py
+++ b/rslp/large_scale_embeddings/write_jobs.py
@@ -1,0 +1,275 @@
+"""Enqueue OlmoEarth embedding prediction jobs on a Beaker queue.
+
+The world is divided into TILE_SIZE x TILE_SIZE UTM tiles. Each tile becomes one
+prediction job for a single user-provided reference timestamp. Tiles that don't
+intersect their zone's canonical wedge, or that contain no crops to process (e.g.
+entirely ocean), are excluded, along with tiles whose completion marker already
+exists. Jobs are written to a Beaker queue, where they are processed by rslp.common
+workers running the ``predict`` workflow.
+
+The tile size is fixed to 32768x32768 here; the prediction pipeline itself accepts
+any tile size that is a multiple of PATCH_SIZE.
+"""
+
+import json
+import random
+from collections.abc import Generator
+from datetime import datetime
+
+import shapely
+import shapely.geometry
+import tqdm
+from rasterio.crs import CRS
+from rslearn.const import WGS84_PROJECTION
+from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
+from rslearn.utils.get_utm_ups_crs import get_proj_bounds
+from upath import UPath
+
+import rslp.common.worker
+from rslp.log_utils import get_logger
+
+from .predict_pipeline import (
+    PATCH_SIZE,
+    RESOLUTION,
+    EmbeddingInputs,
+    get_marker_fname,
+)
+from .tiling import bounds_intersect_wedge, get_zone_wedge, list_kept_crops
+
+logger = get_logger(__name__)
+
+# Fixed tile size for this job-writer (the prediction pipeline supports any multiple
+# of PATCH_SIZE).
+TILE_SIZE = 32768
+
+# When filtering tiles by GeoJSON, skip a UTM zone entirely if no feature's WGS84
+# bounding box comes within this many degrees longitude of the zone. This avoids
+# projecting shapes into distant UTM zones where the transform is unreliable.
+GEOJSON_ZONE_LONGITUDE_MARGIN = 6.0
+
+
+def enumerate_tiles_in_zone(utm_zone: CRS) -> Generator[tuple[int, int], None, None]:
+    """List the (column, row) of all TILE_SIZE tiles within a UTM zone.
+
+    Args:
+        utm_zone: the CRS which must correspond to a UTM EPSG.
+
+    Returns:
+        generator of (column, row) of the tiles that are needed.
+    """
+    crs_bbox = STGeometry(
+        Projection(utm_zone, 1, 1),
+        shapely.box(*get_proj_bounds(utm_zone)),
+        None,
+    )
+    projection = Projection(utm_zone, RESOLUTION, -RESOLUTION)
+    pixel_bbox = crs_bbox.to_projection(projection)
+    zone_bounds = tuple(int(value) for value in pixel_bbox.shp.bounds)
+
+    for col in range(zone_bounds[0] // TILE_SIZE, zone_bounds[2] // TILE_SIZE + 1):
+        for row in range(zone_bounds[1] // TILE_SIZE, zone_bounds[3] // TILE_SIZE + 1):
+            yield (col, row)
+
+
+def get_jobs(
+    inputs: EmbeddingInputs,
+    timestamp: datetime,
+    out_path: str,
+    completed_path: str,
+    epsg_code: int | None = None,
+    wgs84_bounds: tuple[float, float, float, float] | None = None,
+    geojson_fname: str | None = None,
+    count: int | None = None,
+) -> list[list[str]]:
+    """Get the prediction jobs (one per tile).
+
+    Tiles whose completion markers already exist are excluded, along with tiles that
+    don't intersect their zone's canonical wedge or contain no crops to process.
+
+    Args:
+        inputs: which input variant to use. Different variants produce different
+            embeddings so they must use different out_path/completed_path.
+        timestamp: the reference timestamp (start of the one-year input period). Must
+            have timezone.
+        out_path: the directory to write the embedding GeoTIFFs.
+        completed_path: the directory for per-tile completion markers.
+        epsg_code: limit tasks to this UTM zone (EPSG code); default all UTM zones.
+        wgs84_bounds: limit tasks to ones intersecting these WGS84 bounds.
+        geojson_fname: limit tasks to tiles intersecting a feature in this GeoJSON
+            file (features must be in WGS84 coordinates).
+        count: limit to this many tasks (randomly sampled).
+
+    Returns:
+        a list of worker argument lists, one per TILE_SIZE tile.
+    """
+    if epsg_code:
+        utm_zones = [CRS.from_epsg(epsg_code)]
+    else:
+        utm_zones = [CRS.from_epsg(code) for code in range(32601, 32661)]
+        utm_zones += [CRS.from_epsg(code) for code in range(32701, 32761)]
+
+    geojson_shapes: list[shapely.Geometry] | None = None
+    if geojson_fname is not None:
+        with UPath(geojson_fname).open() as f:
+            feature_collection = json.load(f)
+        geojson_shapes = [
+            shapely.geometry.shape(feature["geometry"])
+            for feature in feature_collection["features"]
+        ]
+
+    tasks: list[tuple[Projection, PixelBounds]] = []
+    for utm_zone in tqdm.tqdm(utm_zones, desc="Enumerating tasks across UTM zones"):
+        projection = Projection(utm_zone, RESOLUTION, -RESOLUTION)
+        wedge = get_zone_wedge(utm_zone, RESOLUTION)
+
+        # Project the GeoJSON shapes near this zone into the zone's pixel coordinate
+        # system (skipping the zone if there are none nearby).
+        zone_geojson_shapes: list[shapely.Geometry] | None = None
+        if geojson_shapes is not None:
+            zone_number = utm_zone.to_epsg() % 100
+            zone_lon_min = -180 + (zone_number - 1) * 6
+            zone_lon_max = zone_lon_min + 6
+            zone_geojson_shapes = []
+            for shp in geojson_shapes:
+                shp_bounds = shp.bounds
+                if shp_bounds[2] < zone_lon_min - GEOJSON_ZONE_LONGITUDE_MARGIN:
+                    continue
+                if shp_bounds[0] > zone_lon_max + GEOJSON_ZONE_LONGITUDE_MARGIN:
+                    continue
+                zone_geojson_shapes.append(
+                    STGeometry(WGS84_PROJECTION, shp, None)
+                    .to_projection(projection)
+                    .shp
+                )
+            if len(zone_geojson_shapes) == 0:
+                continue
+
+        user_bounds_in_proj: PixelBounds | None = None
+        if wgs84_bounds is not None:
+            dst_geom = STGeometry(
+                WGS84_PROJECTION, shapely.box(*wgs84_bounds), None
+            ).to_projection(projection)
+            user_bounds_in_proj = (
+                int(dst_geom.shp.bounds[0]),
+                int(dst_geom.shp.bounds[1]),
+                int(dst_geom.shp.bounds[2]),
+                int(dst_geom.shp.bounds[3]),
+            )
+
+        for col, row in enumerate_tiles_in_zone(utm_zone):
+            if user_bounds_in_proj is not None:
+                if (col + 1) * TILE_SIZE < user_bounds_in_proj[0]:
+                    continue
+                if col * TILE_SIZE >= user_bounds_in_proj[2]:
+                    continue
+                if (row + 1) * TILE_SIZE < user_bounds_in_proj[1]:
+                    continue
+                if row * TILE_SIZE >= user_bounds_in_proj[3]:
+                    continue
+
+            bounds = (
+                col * TILE_SIZE,
+                row * TILE_SIZE,
+                (col + 1) * TILE_SIZE,
+                (row + 1) * TILE_SIZE,
+            )
+
+            # Skip tiles that don't intersect any GeoJSON feature.
+            if zone_geojson_shapes is not None:
+                tile_box = shapely.box(*bounds)
+                if not any(shp.intersects(tile_box) for shp in zone_geojson_shapes):
+                    continue
+
+            # Skip tiles outside the zone's canonical wedge (they are covered by the
+            # neighboring UTM zone).
+            if not bounds_intersect_wedge(wedge, bounds):
+                continue
+            # Skip tiles with no crops to process (e.g. entirely ocean).
+            if len(list_kept_crops(projection, bounds, PATCH_SIZE, wedge=wedge)) == 0:
+                continue
+
+            tasks.append((projection, bounds))
+
+    logger.info("Got %d total tasks", len(tasks))
+
+    # Remove tasks where the completion marker already exists.
+    completed_upath = UPath(completed_path)
+    if completed_upath.exists():
+        existing_marker_fnames = {fname.name for fname in completed_upath.iterdir()}
+        tasks = [
+            (projection, bounds)
+            for projection, bounds in tasks
+            if get_marker_fname(completed_path, projection, bounds).name
+            not in existing_marker_fnames
+        ]
+    logger.info("Got %d tasks that are uncompleted", len(tasks))
+
+    # Sample down to count if requested.
+    if count is not None and len(tasks) > count:
+        tasks = random.sample(tasks, count)
+        logger.info("Randomly sampled %d tasks", len(tasks))
+
+    # Convert tasks to worker jobs (one per tile).
+    time_range_json = json.dumps([timestamp.isoformat(), timestamp.isoformat()])
+    jobs = []
+    for projection, bounds in tasks:
+        cur_args = [
+            "--inputs",
+            inputs.name,
+            "--projection_json",
+            json.dumps(projection.serialize()),
+            "--bounds",
+            json.dumps(list(bounds)),
+            "--time_range",
+            time_range_json,
+            "--out_path",
+            out_path,
+            "--completed_path",
+            completed_path,
+        ]
+        jobs.append(cur_args)
+
+    return jobs
+
+
+def write_jobs(
+    inputs: EmbeddingInputs,
+    timestamp: datetime,
+    out_path: str,
+    completed_path: str,
+    queue_name: str,
+    epsg_code: int | None = None,
+    wgs84_bounds: tuple[float, float, float, float] | None = None,
+    geojson_fname: str | None = None,
+    count: int | None = None,
+) -> None:
+    """Enumerate tiles for one reference timestamp and write jobs to a Beaker queue.
+
+    Args:
+        inputs: which input variant to use. Different variants produce different
+            embeddings so they must use different out_path/completed_path.
+        timestamp: the reference timestamp (start of the one-year input period). Must
+            have timezone.
+        out_path: the directory to write the embedding GeoTIFFs.
+        completed_path: the directory for per-tile completion markers.
+        queue_name: the Beaker queue to write the job entries to.
+        epsg_code: limit tasks to this UTM zone (EPSG code); default all UTM zones.
+        wgs84_bounds: limit tasks to ones intersecting these WGS84 bounds.
+        geojson_fname: limit tasks to tiles intersecting a feature in this GeoJSON
+            file (features must be in WGS84 coordinates).
+        count: limit to this many tasks (randomly sampled).
+    """
+    jobs = get_jobs(
+        inputs=inputs,
+        timestamp=timestamp,
+        out_path=out_path,
+        completed_path=completed_path,
+        epsg_code=epsg_code,
+        wgs84_bounds=wgs84_bounds,
+        geojson_fname=geojson_fname,
+        count=count,
+    )
+    # Shuffle so outputs start appearing from random parts of the world (aids
+    # debugging).
+    random.shuffle(jobs)
+    rslp.common.worker.write_jobs(queue_name, "large_scale_embeddings", "predict", jobs)

--- a/rslp/large_scale_embeddings/write_jobs.py
+++ b/rslp/large_scale_embeddings/write_jobs.py
@@ -19,22 +19,27 @@ from datetime import datetime
 import shapely
 import shapely.geometry
 import tqdm
-from rasterio.crs import CRS
 from rslearn.const import WGS84_PROJECTION
 from rslearn.utils.geometry import PixelBounds, Projection, STGeometry
-from rslearn.utils.get_utm_ups_crs import get_proj_bounds
 from upath import UPath
 
 import rslp.common.worker
 from rslp.log_utils import get_logger
 
+from . import zarr_store
 from .predict_pipeline import (
+    EMBEDDING_DIM,
     PATCH_SIZE,
     RESOLUTION,
     EmbeddingInputs,
     get_marker_fname,
 )
-from .tiling import bounds_intersect_wedge, get_zone_wedge, list_kept_crops
+from .tiling import (
+    bounds_intersect_wedge,
+    get_zone_grid,
+    get_zone_wedge,
+    list_kept_crops,
+)
 
 logger = get_logger(__name__)
 
@@ -48,35 +53,30 @@ TILE_SIZE = 32768
 GEOJSON_ZONE_LONGITUDE_MARGIN = 6.0
 
 
-def enumerate_tiles_in_zone(utm_zone: CRS) -> Generator[tuple[int, int], None, None]:
+def enumerate_tiles_in_zone(zone_number: int) -> Generator[tuple[int, int], None, None]:
     """List the (column, row) of all TILE_SIZE tiles within a UTM zone.
 
     Args:
-        utm_zone: the CRS which must correspond to a UTM EPSG.
+        zone_number: the UTM zone number (1-60).
 
     Returns:
         generator of (column, row) of the tiles that are needed.
     """
-    crs_bbox = STGeometry(
-        Projection(utm_zone, 1, 1),
-        shapely.box(*get_proj_bounds(utm_zone)),
-        None,
+    _, (origin_x, origin_y), (height, width) = get_zone_grid(
+        zone_number, RESOLUTION, TILE_SIZE
     )
-    projection = Projection(utm_zone, RESOLUTION, -RESOLUTION)
-    pixel_bbox = crs_bbox.to_projection(projection)
-    zone_bounds = tuple(int(value) for value in pixel_bbox.shp.bounds)
-
-    for col in range(zone_bounds[0] // TILE_SIZE, zone_bounds[2] // TILE_SIZE + 1):
-        for row in range(zone_bounds[1] // TILE_SIZE, zone_bounds[3] // TILE_SIZE + 1):
+    for col in range(origin_x // TILE_SIZE, (origin_x + width) // TILE_SIZE):
+        for row in range(origin_y // TILE_SIZE, (origin_y + height) // TILE_SIZE):
             yield (col, row)
 
 
 def get_jobs(
     inputs: EmbeddingInputs,
     timestamp: datetime,
-    out_path: str,
+    store_path: str,
     completed_path: str,
     checkpoint_path: str,
+    time_index: int,
     patch_size: int = 1,
     window_size: int = 16,
     overlap_size: int = 4,
@@ -85,42 +85,55 @@ def get_jobs(
     wgs84_bounds: tuple[float, float, float, float] | None = None,
     geojson_fname: str | None = None,
     count: int | None = None,
+    job_size: int = TILE_SIZE,
 ) -> list[list[str]]:
-    """Get the prediction jobs (one per tile).
+    """Get the prediction jobs (one per job_size block).
 
-    Tiles whose completion markers already exist are excluded, along with tiles that
-    don't intersect their zone's canonical wedge or contain no crops to process.
+    Each UTM zone number (1-60) is processed once in its northern CRS (EPSG:326NN),
+    spanning both hemispheres. Tiles whose completion markers already exist are
+    excluded, along with tiles that don't intersect their zone's canonical wedge or
+    contain no crops to process.
 
     Args:
         inputs: which input variant to use. Different variants produce different
-            embeddings so they must use different out_path/completed_path.
+            embeddings so they must use different stores.
         timestamp: the reference timestamp (start of the one-year input period). Must
             have timezone.
-        out_path: the directory to write the embedding GeoTIFFs.
+        store_path: the GeoZarr store to write embeddings into.
         completed_path: the directory for per-tile completion markers.
         checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
             Different checkpoints produce different embeddings so they must use
-            different out_path/completed_path (same for patch_size, window_size, and
+            different store_path/completed_path (same for patch_size, window_size, and
             overlap_size below).
+        time_index: the index into the store's time axis for this reference year.
         patch_size: the encoder patch size; yields one embedding per patch_size x
             patch_size pixels.
         window_size: the size of the crops the model operates on.
         overlap_size: overlap in pixels between adjacent crops.
         compile_model: whether to compile the encoder transformer blocks.
-        epsg_code: limit tasks to this UTM zone (EPSG code); default all UTM zones.
+        epsg_code: limit tasks to the zone of this UTM EPSG code (326NN or 327NN both
+            map to zone NN); default all UTM zones.
         wgs84_bounds: limit tasks to ones intersecting these WGS84 bounds.
         geojson_fname: limit tasks to tiles intersecting a feature in this GeoJSON
             file (features must be in WGS84 coordinates).
         count: limit to this many tasks (randomly sampled).
+        job_size: the pixel size of each job, a divisor of TILE_SIZE and a multiple
+            of PATCH_SIZE. Defaults to one job per TILE_SIZE tile. Smaller jobs cost
+            more fixed overhead (model load and compile per job) but each finishes
+            far sooner, which matters on preemptible workers: a job that outlives the
+            gaps between preemptions never completes at all.
 
     Returns:
-        a list of worker argument lists, one per TILE_SIZE tile.
+        a list of worker argument lists, one per job_size block.
     """
+    if job_size % PATCH_SIZE != 0:
+        raise ValueError(f"job_size {job_size} must be a multiple of {PATCH_SIZE}")
+    if TILE_SIZE % job_size != 0:
+        raise ValueError(f"job_size {job_size} must divide TILE_SIZE {TILE_SIZE}")
     if epsg_code:
-        utm_zones = [CRS.from_epsg(epsg_code)]
+        zone_numbers = [epsg_code % 100]
     else:
-        utm_zones = [CRS.from_epsg(code) for code in range(32601, 32661)]
-        utm_zones += [CRS.from_epsg(code) for code in range(32701, 32761)]
+        zone_numbers = list(range(1, 61))
 
     geojson_shapes: list[shapely.Geometry] | None = None
     if geojson_fname is not None:
@@ -132,15 +145,16 @@ def get_jobs(
         ]
 
     tasks: list[tuple[Projection, PixelBounds]] = []
-    for utm_zone in tqdm.tqdm(utm_zones, desc="Enumerating tasks across UTM zones"):
-        projection = Projection(utm_zone, RESOLUTION, -RESOLUTION)
-        wedge = get_zone_wedge(utm_zone, RESOLUTION)
+    for zone_number in tqdm.tqdm(
+        zone_numbers, desc="Enumerating tasks across UTM zones"
+    ):
+        projection, _, _ = get_zone_grid(zone_number, RESOLUTION, TILE_SIZE)
+        wedge = get_zone_wedge(projection.crs, RESOLUTION)
 
         # Project the GeoJSON shapes near this zone into the zone's pixel coordinate
         # system (skipping the zone if there are none nearby).
         zone_geojson_shapes: list[shapely.Geometry] | None = None
         if geojson_shapes is not None:
-            zone_number = utm_zone.to_epsg() % 100
             zone_lon_min = -180 + (zone_number - 1) * 6
             zone_lon_max = zone_lon_min + 6
             zone_geojson_shapes = []
@@ -170,7 +184,7 @@ def get_jobs(
                 int(dst_geom.shp.bounds[3]),
             )
 
-        for col, row in enumerate_tiles_in_zone(utm_zone):
+        for col, row in enumerate_tiles_in_zone(zone_number):
             if user_bounds_in_proj is not None:
                 if (col + 1) * TILE_SIZE < user_bounds_in_proj[0]:
                     continue
@@ -202,7 +216,25 @@ def get_jobs(
             if len(list_kept_crops(projection, bounds, PATCH_SIZE, wedge=wedge)) == 0:
                 continue
 
-            tasks.append((projection, bounds))
+            # Split the tile into job_size blocks. Subdividing the TILE_SIZE grid
+            # (rather than re-gridding the zone) keeps every block on the same
+            # absolute pixel coordinates the store was created with.
+            for sub_x in range(bounds[0], bounds[2], job_size):
+                for sub_y in range(bounds[1], bounds[3], job_size):
+                    sub_bounds = (sub_x, sub_y, sub_x + job_size, sub_y + job_size)
+                    if zone_geojson_shapes is not None and not any(
+                        shp.intersects(shapely.box(*sub_bounds))
+                        for shp in zone_geojson_shapes
+                    ):
+                        continue
+                    if not bounds_intersect_wedge(wedge, sub_bounds):
+                        continue
+                    if (
+                        len(list_kept_crops(projection, sub_bounds, PATCH_SIZE, wedge=wedge))
+                        == 0
+                    ):
+                        continue
+                    tasks.append((projection, sub_bounds))
 
     logger.info("Got %d total tasks", len(tasks))
 
@@ -236,12 +268,14 @@ def get_jobs(
             json.dumps(list(bounds)),
             "--time_range",
             time_range_json,
-            "--out_path",
-            out_path,
+            "--store_path",
+            store_path,
             "--completed_path",
             completed_path,
             "--checkpoint_path",
             checkpoint_path,
+            "--time_index",
+            str(time_index),
             "--patch_size",
             str(patch_size),
             "--window_size",
@@ -259,7 +293,7 @@ def get_jobs(
 def write_jobs(
     inputs: EmbeddingInputs,
     timestamp: datetime,
-    out_path: str,
+    store_path: str,
     completed_path: str,
     queue_name: str,
     checkpoint_path: str,
@@ -271,38 +305,53 @@ def write_jobs(
     wgs84_bounds: tuple[float, float, float, float] | None = None,
     geojson_fname: str | None = None,
     count: int | None = None,
+    job_size: int = TILE_SIZE,
 ) -> None:
     """Enumerate tiles for one reference timestamp and write jobs to a Beaker queue.
 
+    The store must already be initialized (see init_store); its time axis determines
+    the time index for this timestamp's year.
+
     Args:
         inputs: which input variant to use. Different variants produce different
-            embeddings so they must use different out_path/completed_path.
+            embeddings so they must use different stores.
         timestamp: the reference timestamp (start of the one-year input period). Must
             have timezone.
-        out_path: the directory to write the embedding GeoTIFFs.
+        store_path: the GeoZarr store to write embeddings into.
         completed_path: the directory for per-tile completion markers.
         queue_name: the Beaker queue to write the job entries to.
         checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
             Different checkpoints produce different embeddings so they must use
-            different out_path/completed_path (same for patch_size, window_size, and
+            different store_path/completed_path (same for patch_size, window_size, and
             overlap_size below).
         patch_size: the encoder patch size; yields one embedding per patch_size x
             patch_size pixels.
         window_size: the size of the crops the model operates on.
         overlap_size: overlap in pixels between adjacent crops.
         compile_model: whether to compile the encoder transformer blocks.
-        epsg_code: limit tasks to this UTM zone (EPSG code); default all UTM zones.
+        epsg_code: limit tasks to the zone of this UTM EPSG code; default all zones.
         wgs84_bounds: limit tasks to ones intersecting these WGS84 bounds.
         geojson_fname: limit tasks to tiles intersecting a feature in this GeoJSON
             file (features must be in WGS84 coordinates).
         count: limit to this many tasks (randomly sampled).
+        job_size: the pixel size of each job (see get_jobs). Defaults to one job per
+            TILE_SIZE tile.
     """
+    years = zarr_store.get_store_years(store_path)
+    if timestamp.year not in years:
+        raise ValueError(
+            f"store {store_path} has years {years} but timestamp year "
+            f"{timestamp.year} is not among them (run init_store first)"
+        )
+    time_index = years.index(timestamp.year)
+
     jobs = get_jobs(
         inputs=inputs,
         timestamp=timestamp,
-        out_path=out_path,
+        store_path=store_path,
         completed_path=completed_path,
         checkpoint_path=checkpoint_path,
+        time_index=time_index,
         patch_size=patch_size,
         window_size=window_size,
         overlap_size=overlap_size,
@@ -311,8 +360,64 @@ def write_jobs(
         wgs84_bounds=wgs84_bounds,
         geojson_fname=geojson_fname,
         count=count,
+        job_size=job_size,
     )
     # Shuffle so outputs start appearing from random parts of the world (aids
     # debugging).
     random.shuffle(jobs)
     rslp.common.worker.write_jobs(queue_name, "large_scale_embeddings", "predict", jobs)
+
+
+def init_store(
+    store_path: str,
+    years: list[int],
+    model_url: str,
+    source_data: list[str],
+    zone_numbers: list[int] | None = None,
+    patch_size: int = 1,
+    build_version: str = "0.0.1",
+    zstd_level: int = zarr_store.DEFAULT_ZSTD_LEVEL,
+    overwrite: bool = False,
+) -> None:
+    """Initialize the GeoZarr store for a variant before enqueuing prediction jobs.
+
+    Creates the root group and one group per UTM zone with an empty sharded int8
+    embedding array spanning the given years. Run once per store, before write_jobs.
+
+    Args:
+        store_path: the GeoZarr store path or URL to create.
+        years: the annual reference years, defining the time axis.
+        model_url: URL reference to the encoder model (e.g. a HuggingFace repo).
+        source_data: URLs of the source datasets.
+        zone_numbers: the UTM zone numbers to create; defaults to all of 1-60.
+        patch_size: the encoder patch size; the store grid is at 1/patch_size of the
+            input resolution, so it must match the patch_size used by write_jobs.
+        build_version: version of the software that built the store.
+        zstd_level: zstd compression level for the arrays.
+        overwrite: whether to overwrite an existing store.
+    """
+    if zone_numbers is None:
+        zone_numbers = list(range(1, 61))
+    if PATCH_SIZE % patch_size != 0:
+        raise ValueError(f"patch_size must divide {PATCH_SIZE}, got {patch_size}")
+    # The store grid is at the output (embedding) resolution, which is 1/patch_size of
+    # the input resolution. One output window (= one shard) is PATCH_SIZE / patch_size
+    # pixels, and the tile size scales down the same way.
+    output_resolution = RESOLUTION * patch_size
+    output_tile_size = TILE_SIZE // patch_size
+    output_shard_size = PATCH_SIZE // patch_size
+    zarr_store.init_store(
+        store_path=store_path,
+        zone_numbers=zone_numbers,
+        years=years,
+        model_url=model_url,
+        source_data=source_data,
+        resolution=output_resolution,
+        tile_size=output_tile_size,
+        dimensions=EMBEDDING_DIM,
+        chunk_size=min(zarr_store.DEFAULT_CHUNK_SIZE, output_shard_size),
+        shard_size=output_shard_size,
+        zstd_level=zstd_level,
+        build_version=build_version,
+        overwrite=overwrite,
+    )

--- a/rslp/large_scale_embeddings/write_jobs.py
+++ b/rslp/large_scale_embeddings/write_jobs.py
@@ -230,7 +230,11 @@ def get_jobs(
                     if not bounds_intersect_wedge(wedge, sub_bounds):
                         continue
                     if (
-                        len(list_kept_crops(projection, sub_bounds, PATCH_SIZE, wedge=wedge))
+                        len(
+                            list_kept_crops(
+                                projection, sub_bounds, PATCH_SIZE, wedge=wedge
+                            )
+                        )
                         == 0
                     ):
                         continue

--- a/rslp/large_scale_embeddings/write_jobs.py
+++ b/rslp/large_scale_embeddings/write_jobs.py
@@ -76,6 +76,11 @@ def get_jobs(
     timestamp: datetime,
     out_path: str,
     completed_path: str,
+    checkpoint_path: str,
+    patch_size: int = 1,
+    window_size: int = 16,
+    overlap_size: int = 4,
+    compile_model: bool = True,
     epsg_code: int | None = None,
     wgs84_bounds: tuple[float, float, float, float] | None = None,
     geojson_fname: str | None = None,
@@ -93,6 +98,15 @@ def get_jobs(
             have timezone.
         out_path: the directory to write the embedding GeoTIFFs.
         completed_path: the directory for per-tile completion markers.
+        checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
+            Different checkpoints produce different embeddings so they must use
+            different out_path/completed_path (same for patch_size, window_size, and
+            overlap_size below).
+        patch_size: the encoder patch size; yields one embedding per patch_size x
+            patch_size pixels.
+        window_size: the size of the crops the model operates on.
+        overlap_size: overlap in pixels between adjacent crops.
+        compile_model: whether to compile the encoder transformer blocks.
         epsg_code: limit tasks to this UTM zone (EPSG code); default all UTM zones.
         wgs84_bounds: limit tasks to ones intersecting these WGS84 bounds.
         geojson_fname: limit tasks to tiles intersecting a feature in this GeoJSON
@@ -226,6 +240,16 @@ def get_jobs(
             out_path,
             "--completed_path",
             completed_path,
+            "--checkpoint_path",
+            checkpoint_path,
+            "--patch_size",
+            str(patch_size),
+            "--window_size",
+            str(window_size),
+            "--overlap_size",
+            str(overlap_size),
+            "--compile_model",
+            "true" if compile_model else "false",
         ]
         jobs.append(cur_args)
 
@@ -238,6 +262,11 @@ def write_jobs(
     out_path: str,
     completed_path: str,
     queue_name: str,
+    checkpoint_path: str,
+    patch_size: int = 1,
+    window_size: int = 16,
+    overlap_size: int = 4,
+    compile_model: bool = True,
     epsg_code: int | None = None,
     wgs84_bounds: tuple[float, float, float, float] | None = None,
     geojson_fname: str | None = None,
@@ -253,6 +282,15 @@ def write_jobs(
         out_path: the directory to write the embedding GeoTIFFs.
         completed_path: the directory for per-tile completion markers.
         queue_name: the Beaker queue to write the job entries to.
+        checkpoint_path: the OlmoEarth checkpoint to compute embeddings with.
+            Different checkpoints produce different embeddings so they must use
+            different out_path/completed_path (same for patch_size, window_size, and
+            overlap_size below).
+        patch_size: the encoder patch size; yields one embedding per patch_size x
+            patch_size pixels.
+        window_size: the size of the crops the model operates on.
+        overlap_size: overlap in pixels between adjacent crops.
+        compile_model: whether to compile the encoder transformer blocks.
         epsg_code: limit tasks to this UTM zone (EPSG code); default all UTM zones.
         wgs84_bounds: limit tasks to ones intersecting these WGS84 bounds.
         geojson_fname: limit tasks to tiles intersecting a feature in this GeoJSON
@@ -264,6 +302,11 @@ def write_jobs(
         timestamp=timestamp,
         out_path=out_path,
         completed_path=completed_path,
+        checkpoint_path=checkpoint_path,
+        patch_size=patch_size,
+        window_size=window_size,
+        overlap_size=overlap_size,
+        compile_model=compile_model,
         epsg_code=epsg_code,
         wgs84_bounds=wgs84_bounds,
         geojson_fname=geojson_fname,

--- a/rslp/large_scale_embeddings/zarr_store.py
+++ b/rslp/large_scale_embeddings/zarr_store.py
@@ -1,0 +1,363 @@
+"""GeoZarr store for global quantized OlmoEarth embeddings.
+
+Writes embeddings to a Zarr v3 store following the geoemb embeddings-zarr-convention
+(https://github.com/geo-embeddings/embeddings-zarr-convention). The store uses the
+``utm_zones`` spatial layout: one group per UTM zone number named ``utm{NN}``, each in
+its northern CRS (EPSG:326NN) with a continuous northing axis spanning both
+hemispheres (see tiling.get_zone_grid). Each zone group holds one ``embeddings`` array
+with dimensions ``(time, band, y, x)`` where ``band`` is the 128-dim embedding vector
+and ``time`` is the annual reference years.
+
+The store is created once by ``init_store`` (root + all zone groups, arrays, and
+consolidated metadata). Prediction workers then only write disjoint data regions via
+``write_window_region``, never mutating metadata, so concurrent writes are safe. To
+keep concurrent writes on disjoint shards, the shard spatial size must equal the
+window (PATCH_SIZE) size so each window owns exactly one shard.
+
+Quantization is the signed-power (AlphaEarth-style) scheme from model.py; it is not
+expressible with the convention's scalar/array scale objects, so it is described with
+a custom ``method`` plus a ``link`` to the formula (see the project README).
+"""
+
+import numpy as np
+import zarr
+from rslearn.utils.geometry import PixelBounds, Projection
+from zarr.codecs import ZstdCodec
+
+from rslp.log_utils import get_logger
+
+from .model import NODATA_VALUE
+from .tiling import get_zone_grid
+
+logger = get_logger(__name__)
+
+# Name of the embedding array within each zone group.
+EMBEDDINGS_ARRAY = "embeddings"
+
+# Zarr v3 dimension order for the embedding array.
+EMBEDDING_DIMENSIONS = ("time", "band", "y", "x")
+
+# Default chunk (inner) and shard (outer storage unit) spatial sizes, and zstd level.
+# The shard size must equal the window size (PATCH_SIZE) so each prediction window
+# writes exactly one shard, keeping concurrent region writes on disjoint objects.
+# chunk=256 was chosen from a small-AOI read benchmark on real embeddings: it roughly
+# halves the bytes read per interactive AOI versus 512, at ~14% more storage.
+DEFAULT_CHUNK_SIZE = 256
+DEFAULT_SHARD_SIZE = 2048
+DEFAULT_ZSTD_LEVEL = 1
+# Chunk size (in elements) for the 1-D x/y coordinate arrays. They are linear ramps
+# so they compress to almost nothing under zstd.
+COORD_CHUNK_SIZE = 65536
+
+# Registered zarr_conventions entries (see the geoemb spec and its tessera example).
+GEOEMB_CONVENTION = {
+    "schema_url": "https://raw.githubusercontent.com/geo-embeddings/embeddings-zarr-convention/refs/tags/v1/schema.json",
+    "spec_url": "https://github.com/geo-embeddings/embeddings-zarr-convention/blob/v1/README.md",
+    "uuid": "61c12cc5-0e28-4056-999a-480cf3fb7e4c",
+    "name": "geoemb:",
+    "description": "Geoembeddings convention for geospatial embedding arrays with model provenance",
+}
+SPATIAL_CONVENTION = {
+    "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/refs/tags/v1/schema.json",
+    "spec_url": "https://github.com/zarr-conventions/spatial/blob/v1/README.md",
+    "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+    "name": "spatial:",
+    "description": "Spatial coordinate information",
+}
+PROJ_CONVENTION = {
+    "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
+    "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+    "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+    "name": "proj:",
+    "description": "Coordinate reference system information for geospatial data",
+}
+ZARR_CONVENTIONS = [GEOEMB_CONVENTION, SPATIAL_CONVENTION, PROJ_CONVENTION]
+
+# Default URL documenting the signed-power quantization/dequantization formula.
+DEFAULT_QUANTIZATION_LINK = (
+    "https://github.com/allenai/rslearn_projects/blob/master/"
+    "rslp/large_scale_embeddings/README.md"
+)
+
+
+def zone_group_name(zone_number: int) -> str:
+    """Get the group name for a UTM zone number (e.g. 10 -> 'utm10')."""
+    return f"utm{zone_number:02d}"
+
+
+def get_store_years(store_path: str, storage_options: dict | None = None) -> list[int]:
+    """Read the store's time axis (reference years) from the first zone group.
+
+    Args:
+        store_path: the Zarr store path or URL.
+        storage_options: fsspec storage options for remote stores.
+
+    Returns:
+        the list of years defining the store's time axis.
+    """
+    root = zarr.open_group(store=store_path, mode="r", storage_options=storage_options)
+    for name in sorted(root.keys()):
+        if name.startswith("utm"):
+            return [int(value) for value in root[name]["time"][:]]
+    raise ValueError(f"no utm zone groups found in store {store_path}")
+
+
+def _quantization_attrs(link: str) -> dict:
+    """Build the geoemb:quantization object for the signed-power scheme."""
+    return {
+        "method": "signed_power",
+        "original_dtype": "float32",
+        "quantized_dtype": "int8",
+        "link": link,
+    }
+
+
+def build_geoemb_attrs(
+    dimensions: int,
+    model_url: str,
+    source_data: list[str],
+    gsd: float,
+    build_version: str,
+    quantization_link: str = DEFAULT_QUANTIZATION_LINK,
+) -> dict:
+    """Build the geoemb convention attributes (shared by the root and zone groups).
+
+    Args:
+        dimensions: the embedding vector dimensionality.
+        model_url: URL reference to the encoder model.
+        source_data: URLs of the source datasets.
+        gsd: ground sample distance in meters.
+        build_version: version of the software that built the store.
+        quantization_link: URL documenting the dequantization formula.
+
+    Returns:
+        a dict of geoemb: attributes.
+    """
+    return {
+        "geoemb:type": "pixel",
+        "geoemb:dimensions": dimensions,
+        "geoemb:model": model_url,
+        "geoemb:source_data": list(source_data),
+        "geoemb:data_type": "int8",
+        "geoemb:gsd": gsd,
+        "geoemb:spatial_layout": "utm_zones",
+        "geoemb:quantization": _quantization_attrs(quantization_link),
+        "geoemb:build_version": build_version,
+    }
+
+
+def build_zone_spatial_attrs(
+    projection: Projection,
+    origin_px: tuple[int, int],
+    shape_px: tuple[int, int],
+) -> dict:
+    """Build the proj:/spatial: attributes for one zone group.
+
+    Args:
+        projection: the northern UTM projection of the zone.
+        origin_px: the (x, y) pixel coordinate of the array's top-left corner.
+        shape_px: the (height, width) of the array in pixels.
+
+    Returns:
+        a dict of proj: and spatial: attributes.
+    """
+    origin_x, origin_y = origin_px
+    height, width = shape_px
+    x_res = projection.x_resolution
+    y_res = projection.y_resolution
+    # Affine mapping array (col, row) -> CRS (easting, northing): the pixel grid has
+    # its origin at CRS (0, 0), so the array corner is at (origin_x * x_res,
+    # origin_y * y_res). y_res is negative so northing decreases with row.
+    corner_x = origin_x * x_res
+    corner_y = origin_y * y_res
+    transform = [x_res, 0.0, corner_x, 0.0, y_res, corner_y]
+    far_x = (origin_x + width) * x_res
+    far_y = (origin_y + height) * y_res
+    bbox = [
+        min(corner_x, far_x),
+        min(corner_y, far_y),
+        max(corner_x, far_x),
+        max(corner_y, far_y),
+    ]
+    return {
+        "proj:code": f"EPSG:{projection.crs.to_epsg()}",
+        "spatial:dimensions": ["y", "x"],
+        "spatial:transform": transform,
+        "spatial:shape": [height, width],
+        "spatial:bbox": bbox,
+        "spatial:registration": "pixel",
+    }
+
+
+def init_store(
+    store_path: str,
+    zone_numbers: list[int],
+    years: list[int],
+    model_url: str,
+    source_data: list[str],
+    resolution: float,
+    tile_size: int,
+    dimensions: int,
+    gsd: float | None = None,
+    build_version: str = "0.0.1",
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    shard_size: int = DEFAULT_SHARD_SIZE,
+    zstd_level: int = DEFAULT_ZSTD_LEVEL,
+    quantization_link: str = DEFAULT_QUANTIZATION_LINK,
+    overwrite: bool = False,
+    storage_options: dict | None = None,
+) -> None:
+    """Create the GeoZarr store skeleton (root, zone groups, arrays, metadata).
+
+    This must be run once before any prediction workers write to the store. Workers
+    then only write data regions, so all metadata is created here to avoid races.
+
+    Args:
+        store_path: the Zarr store path or URL (e.g. gs://bucket/embeddings.zarr).
+        zone_numbers: the UTM zone numbers (1-60) to create groups for.
+        years: the annual reference years, defining the time axis (order preserved).
+        model_url: URL reference to the encoder model.
+        source_data: URLs of the source datasets.
+        resolution: the projection resolution in m/pixel.
+        tile_size: the tile size in pixels (must be a multiple of shard_size).
+        dimensions: the embedding vector dimensionality (the band dimension size).
+        gsd: ground sample distance in meters; defaults to resolution.
+        build_version: version of the software that built the store.
+        chunk_size: inner chunk spatial size for the embedding array.
+        shard_size: outer shard spatial size; must equal the window (PATCH_SIZE) size
+            and be a multiple of chunk_size, and tile_size a multiple of it.
+        zstd_level: zstd compression level for the embedding and coordinate arrays.
+        quantization_link: URL documenting the dequantization formula.
+        overwrite: whether to overwrite an existing store.
+        storage_options: fsspec storage options for remote stores.
+    """
+    if tile_size % shard_size != 0:
+        raise ValueError(f"tile_size {tile_size} must be a multiple of shard_size {shard_size}")
+    if shard_size % chunk_size != 0:
+        raise ValueError(f"shard_size {shard_size} must be a multiple of chunk_size {chunk_size}")
+    if gsd is None:
+        gsd = float(resolution)
+
+    root = zarr.open_group(
+        store=store_path,
+        mode="w" if overwrite else "w-",
+        storage_options=storage_options,
+    )
+    geoemb_attrs = build_geoemb_attrs(
+        dimensions=dimensions,
+        model_url=model_url,
+        source_data=source_data,
+        gsd=gsd,
+        build_version=build_version,
+        quantization_link=quantization_link,
+    )
+    root.attrs.update({"zarr_conventions": ZARR_CONVENTIONS, **geoemb_attrs})
+
+    years_arr = np.array(years, dtype="int32")
+    for zone_number in zone_numbers:
+        projection, origin_px, shape_px = get_zone_grid(zone_number, resolution, tile_size)
+        height, width = shape_px
+        zone_group = root.create_group(zone_group_name(zone_number))
+        zone_group.attrs.update(
+            {
+                "zarr_conventions": ZARR_CONVENTIONS,
+                **geoemb_attrs,
+                **build_zone_spatial_attrs(projection, origin_px, shape_px),
+            }
+        )
+
+        zone_group.create_array(
+            EMBEDDINGS_ARRAY,
+            shape=(len(years), dimensions, height, width),
+            chunks=(1, dimensions, chunk_size, chunk_size),
+            shards=(1, dimensions, shard_size, shard_size),
+            dtype="int8",
+            fill_value=NODATA_VALUE,
+            compressors=[ZstdCodec(level=zstd_level)],
+            dimension_names=EMBEDDING_DIMENSIONS,
+        )
+
+        # Coordinate arrays (pixel centers) for xarray/GeoZarr friendliness.
+        origin_x, origin_y = origin_px
+        time_coord = zone_group.create_array(
+            "time", shape=(len(years),), dtype="int32", dimension_names=("time",)
+        )
+        time_coord[:] = years_arr
+        x_coord = zone_group.create_array(
+            "x",
+            shape=(width,),
+            dtype="float64",
+            chunks=(min(width, COORD_CHUNK_SIZE),),
+            compressors=[ZstdCodec(level=zstd_level)],
+            dimension_names=("x",),
+        )
+        x_coord[:] = (np.arange(width) + origin_x + 0.5) * projection.x_resolution
+        y_coord = zone_group.create_array(
+            "y",
+            shape=(height,),
+            dtype="float64",
+            chunks=(min(height, COORD_CHUNK_SIZE),),
+            compressors=[ZstdCodec(level=zstd_level)],
+            dimension_names=("y",),
+        )
+        y_coord[:] = (np.arange(height) + origin_y + 0.5) * projection.y_resolution
+        logger.info("created zone group %s with shape %s", zone_group_name(zone_number), shape_px)
+
+    zarr.consolidate_metadata(root.store)
+    logger.info("initialized store %s with %d zones", store_path, len(zone_numbers))
+
+
+def write_window_region(
+    store_path: str,
+    zone_number: int,
+    window_bounds: PixelBounds,
+    time_index: int,
+    embeddings: np.ndarray,
+    patch_size: int = 1,
+    storage_options: dict | None = None,
+) -> None:
+    """Write one window's embedding raster into the zone array region.
+
+    The window must be aligned to the store's shard grid (guaranteed when window
+    bounds are multiples of PATCH_SIZE and the shard spatial size equals the window's
+    output size PATCH_SIZE / patch_size), so this writes whole shards and is safe
+    under concurrent writes of disjoint windows. The array origin is read back from
+    the zone group's spatial:transform so it always matches what init_store wrote.
+
+    Args:
+        store_path: the Zarr store path or URL.
+        zone_number: the UTM zone number (1-60) whose group to write into.
+        window_bounds: the window's pixel bounds in the zone's northern CRS, at the
+            input resolution (i.e. multiples of PATCH_SIZE).
+        time_index: the index into the time axis for this reference year.
+        embeddings: the int8 embedding array of shape (band, height, width), at the
+            output resolution (1/patch_size of the input resolution).
+        patch_size: the encoder patch size; the store grid is at 1/patch_size of the
+            input resolution, so the window bounds are divided by it to locate the
+            output region.
+        storage_options: fsspec storage options for remote stores.
+    """
+    group = zarr.open_group(
+        store=store_path,
+        path=zone_group_name(zone_number),
+        mode="r+",
+        storage_options=storage_options,
+    )
+    transform = group.attrs["spatial:transform"]
+    x_res = transform[0]
+    y_res = transform[4]
+    origin_x = round(transform[2] / x_res)
+    origin_y = round(transform[5] / y_res)
+
+    # The store grid is at the output resolution, so map the input-pixel window bounds
+    # down to output pixels before offsetting against the (output-pixel) array origin.
+    col_offset = window_bounds[0] // patch_size - origin_x
+    row_offset = window_bounds[1] // patch_size - origin_y
+    _, height, width = embeddings.shape
+    array = group[EMBEDDINGS_ARRAY]
+    array[
+        time_index,
+        :,
+        row_offset : row_offset + height,
+        col_offset : col_offset + width,
+    ] = embeddings

--- a/rslp/large_scale_embeddings/zarr_store.py
+++ b/rslp/large_scale_embeddings/zarr_store.py
@@ -232,9 +232,13 @@ def init_store(
         storage_options: fsspec storage options for remote stores.
     """
     if tile_size % shard_size != 0:
-        raise ValueError(f"tile_size {tile_size} must be a multiple of shard_size {shard_size}")
+        raise ValueError(
+            f"tile_size {tile_size} must be a multiple of shard_size {shard_size}"
+        )
     if shard_size % chunk_size != 0:
-        raise ValueError(f"shard_size {shard_size} must be a multiple of chunk_size {chunk_size}")
+        raise ValueError(
+            f"shard_size {shard_size} must be a multiple of chunk_size {chunk_size}"
+        )
     if gsd is None:
         gsd = float(resolution)
 
@@ -255,7 +259,9 @@ def init_store(
 
     years_arr = np.array(years, dtype="int32")
     for zone_number in zone_numbers:
-        projection, origin_px, shape_px = get_zone_grid(zone_number, resolution, tile_size)
+        projection, origin_px, shape_px = get_zone_grid(
+            zone_number, resolution, tile_size
+        )
         height, width = shape_px
         zone_group = root.create_group(zone_group_name(zone_number))
         zone_group.attrs.update(
@@ -301,7 +307,11 @@ def init_store(
             dimension_names=("y",),
         )
         y_coord[:] = (np.arange(height) + origin_y + 0.5) * projection.y_resolution
-        logger.info("created zone group %s with shape %s", zone_group_name(zone_number), shape_px)
+        logger.info(
+            "created zone group %s with shape %s",
+            zone_group_name(zone_number),
+            shape_px,
+        )
 
     zarr.consolidate_metadata(root.store)
     logger.info("initialized store %s with %d zones", store_path, len(zone_numbers))

--- a/rslp/olmoearth_pretrain/README.md
+++ b/rslp/olmoearth_pretrain/README.md
@@ -7,8 +7,9 @@ This module contains:
 ## olmoearth_pretrain.Dockerfile
 
 Create a copy of `rslearn_projects` repository with subfolders `docker_build/rslearn`
-(containing https://github.com/allenai/rslearn) and `docker_build/olmoearth_pretrain`
-(containing https://github.com/allenai/olmoearth_pretrain). Then run:
+(containing https://github.com/allenai/rslearn), `docker_build/olmoearth_pretrain`
+(containing https://github.com/allenai/olmoearth_pretrain), and `docker_build/olmoearth_run`.
+Then run:
 
     DOCKER_BUILDKIT=1 docker build -t rslpomp -f olmoearth_pretrain.Dockerfile .
     beaker image create --name rslpomp rslpomp

--- a/tests/unit/large_scale_embeddings/__init__.py
+++ b/tests/unit/large_scale_embeddings/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for rslp.large_scale_embeddings."""

--- a/tests/unit/large_scale_embeddings/test_model.py
+++ b/tests/unit/large_scale_embeddings/test_model.py
@@ -1,0 +1,62 @@
+"""Unit tests for rslp.large_scale_embeddings.model."""
+
+import torch
+from rslearn.models.component import FeatureMaps
+
+from rslp.large_scale_embeddings.model import (
+    NODATA_VALUE,
+    QuantizedEmbeddingHead,
+    dequantize_embeddings,
+    quantize_embeddings,
+)
+
+
+def test_quantize_known_values() -> None:
+    """Quantization matches hardcoded expected values."""
+    values = torch.tensor([0.0, 1.0, -1.0, 0.25, -0.25, 2.0, -2.0])
+    # sqrt(0.25) * 127.5 = 63.75 which rounds to 64; values beyond +/-1 saturate at
+    # +/-127.
+    expected = torch.tensor([0, 127, -127, 64, -64, 127, -127], dtype=torch.int8)
+    assert torch.equal(quantize_embeddings(values), expected)
+
+
+def test_quantize_never_produces_nodata() -> None:
+    """The quantizer never emits the reserved nodata value (-128)."""
+    values = torch.linspace(-100, 100, 100001)
+    quantized = quantize_embeddings(values)
+    assert quantized.dtype == torch.int8
+    assert int(quantized.min()) >= -127
+    assert int(quantized.max()) <= 127
+    assert not (quantized == NODATA_VALUE).any()
+
+
+def test_quantize_roundtrip() -> None:
+    """Dequantizing recovers values in [-1, 1] within the quantization error bound."""
+    values = torch.linspace(-1, 1, 10001)
+    recovered = dequantize_embeddings(quantize_embeddings(values))
+    # In the square-root domain, the rounding error is at most 0.5/127.5, plus the
+    # clamp of 127.5 to 127 at the extremes. Mapping back through the square gives a
+    # worst-case error of about 2 * (1/127.5) in the value domain.
+    assert (recovered - values).abs().max() < 0.02
+
+
+def test_head_quantizes_and_normalizes() -> None:
+    """The head L2-normalizes per pixel then quantizes to int8."""
+    # One sample with C=2, H=1, W=1 whose embedding vector is (3, 4) with norm 5.
+    features = torch.tensor([[[[3.0]], [[4.0]]]])
+    head = QuantizedEmbeddingHead(l2_normalize=True)
+    output = head(FeatureMaps([features]), context=None)
+    # Normalized vector is (0.6, 0.8); sqrt(0.6)*127.5 = 98.76 -> 99 and
+    # sqrt(0.8)*127.5 = 114.03 -> 114.
+    expected = torch.tensor([[[[99]], [[114]]]], dtype=torch.int8)
+    assert output.outputs.dtype == torch.int8
+    assert torch.equal(output.outputs, expected)
+
+
+def test_head_without_normalization() -> None:
+    """With l2_normalize disabled, the head quantizes the raw values."""
+    features = torch.tensor([[[[0.25]], [[-1.0]]]])
+    head = QuantizedEmbeddingHead(l2_normalize=False)
+    output = head(FeatureMaps([features]), context=None)
+    expected = torch.tensor([[[[64]], [[-127]]]], dtype=torch.int8)
+    assert torch.equal(output.outputs, expected)

--- a/tests/unit/large_scale_embeddings/test_tiling.py
+++ b/tests/unit/large_scale_embeddings/test_tiling.py
@@ -1,0 +1,57 @@
+"""Unit tests for rslp.large_scale_embeddings.tiling."""
+
+from rasterio.crs import CRS
+from rslearn.utils.geometry import Projection
+
+from rslp.large_scale_embeddings.tiling import (
+    bounds_intersect_wedge,
+    get_zone_wedge,
+    list_kept_crops,
+)
+
+RESOLUTION = 10
+
+# EPSG:32610 is UTM zone 10N, covering -126 to -120 longitude, 0 to 84 latitude.
+UTM_ZONE_10N = CRS.from_epsg(32610)
+PROJECTION_10N = Projection(UTM_ZONE_10N, RESOLUTION, -RESOLUTION)
+
+
+def _pixel_bounds_around(
+    x_m: float, y_m: float, size: int
+) -> tuple[int, int, int, int]:
+    """Get size x size pixel bounds aligned to size containing the given point."""
+    col = int(x_m / RESOLUTION) // size
+    row = int(-y_m / RESOLUTION) // size
+    return (col * size, row * size, (col + 1) * size, (row + 1) * size)
+
+
+def test_wedge_contains_zone_interior() -> None:
+    """A tile at the zone's central meridian is inside the wedge."""
+    wedge = get_zone_wedge(UTM_ZONE_10N, RESOLUTION)
+    # The central meridian is at x=500000m; Seattle-ish latitude is y~5270000m.
+    bounds = _pixel_bounds_around(500000, 5270000, 2048)
+    assert bounds_intersect_wedge(wedge, bounds)
+
+
+def test_wedge_excludes_far_outside_zone() -> None:
+    """A tile far east of the zone's wedge (in zone 11's territory) is excluded."""
+    wedge = get_zone_wedge(UTM_ZONE_10N, RESOLUTION)
+    # x=1100000m in zone 10N is around -114 longitude, well inside zone 11/12.
+    bounds = _pixel_bounds_around(1100000, 5270000, 2048)
+    assert not bounds_intersect_wedge(wedge, bounds)
+
+
+def test_list_kept_crops_land() -> None:
+    """Crops on land at the zone center are all kept."""
+    # Near Portland, OR (~-122.6, 45.5): x~530000m, y~5040000m in zone 10N.
+    bounds = _pixel_bounds_around(530000, 5040000, 4096)
+    kept = list_kept_crops(PROJECTION_10N, bounds, 2048)
+    assert len(kept) == 4
+
+
+def test_list_kept_crops_ocean() -> None:
+    """Crops in the open ocean are all skipped."""
+    # Pacific ocean far off the coast (~-126 to -125, ~40N): x~150000m, y~4440000m.
+    bounds = _pixel_bounds_around(150000, 4440000, 4096)
+    kept = list_kept_crops(PROJECTION_10N, bounds, 2048)
+    assert len(kept) == 0

--- a/tests/unit/large_scale_embeddings/test_tiling.py
+++ b/tests/unit/large_scale_embeddings/test_tiling.py
@@ -5,11 +5,14 @@ from rslearn.utils.geometry import Projection
 
 from rslp.large_scale_embeddings.tiling import (
     bounds_intersect_wedge,
+    get_zone_grid,
     get_zone_wedge,
     list_kept_crops,
 )
 
 RESOLUTION = 10
+TILE_SIZE = 32768
+SHARD_SIZE = 2048
 
 # EPSG:32610 is UTM zone 10N, covering -126 to -120 longitude, 0 to 84 latitude.
 UTM_ZONE_10N = CRS.from_epsg(32610)
@@ -55,3 +58,26 @@ def test_list_kept_crops_ocean() -> None:
     bounds = _pixel_bounds_around(150000, 4440000, 4096)
     kept = list_kept_crops(PROJECTION_10N, bounds, 2048)
     assert len(kept) == 0
+
+
+def test_wedge_spans_both_hemispheres() -> None:
+    """The northern-CRS wedge covers southern latitudes (negative northing)."""
+    wedge = get_zone_wedge(UTM_ZONE_10N, RESOLUTION)
+    # A point at ~10S on zone 10's central meridian has negative northing in the
+    # northern CRS (EPSG:32610); it must still fall inside the full-latitude wedge.
+    bounds = _pixel_bounds_around(500000, -1105000, 2048)
+    assert bounds_intersect_wedge(wedge, bounds)
+
+
+def test_get_zone_grid_alignment_and_hemispheres() -> None:
+    """get_zone_grid is tile/shard aligned and spans both hemispheres."""
+    projection, origin, shape = get_zone_grid(10, RESOLUTION, TILE_SIZE)
+    origin_x, origin_y = origin
+    height, width = shape
+    assert projection.crs.to_epsg() == 32610
+    # Origin snapped to the tile grid, shape snapped to the shard grid.
+    assert origin_x % TILE_SIZE == 0 and origin_y % TILE_SIZE == 0
+    assert height % SHARD_SIZE == 0 and width % SHARD_SIZE == 0
+    # Row 0 is north of the equator (negative northing -> negative pixel y) and the
+    # array extends south past the equator (positive pixel y).
+    assert origin_y < 0 < origin_y + height

--- a/tests/unit/large_scale_embeddings/test_zarr_store.py
+++ b/tests/unit/large_scale_embeddings/test_zarr_store.py
@@ -119,7 +119,9 @@ def test_write_window_region_roundtrip(tmp_path) -> None:
     by0 = origin_y + 100 * 512
     window_bounds = (bx0, by0, bx0 + 512, by0 + 512)
     embeddings = np.random.randint(-127, 128, size=(4, 512, 512)).astype(np.int8)
-    zs.write_window_region(store, 10, window_bounds, time_index=1, embeddings=embeddings)
+    zs.write_window_region(
+        store, 10, window_bounds, time_index=1, embeddings=embeddings
+    )
 
     array = zarr.open_group(store=store, path="utm10", mode="r")[zs.EMBEDDINGS_ARRAY]
     col0 = bx0 - origin_x

--- a/tests/unit/large_scale_embeddings/test_zarr_store.py
+++ b/tests/unit/large_scale_embeddings/test_zarr_store.py
@@ -1,0 +1,208 @@
+"""Unit tests for rslp.large_scale_embeddings.zarr_store."""
+
+import numpy as np
+import zarr
+
+from rslp.large_scale_embeddings import zarr_store as zs
+from rslp.large_scale_embeddings.tiling import get_zone_grid
+
+RESOLUTION = 10
+TILE_SIZE = 32768
+MODEL_URL = "https://huggingface.co/allenai/OlmoEarth-v1_2-Small"
+SOURCE_DATA = ["https://sentinel.esa.int/web/sentinel/missions/sentinel-2"]
+
+# Required root attributes per the geoemb convention schema.
+REQUIRED_GEOEMB_FIELDS = [
+    "geoemb:type",
+    "geoemb:dimensions",
+    "geoemb:model",
+    "geoemb:source_data",
+    "geoemb:data_type",
+]
+
+
+def _init_small_store(store_path: str, dimensions: int = 4) -> None:
+    """Initialize a store for zone 10 with small dims/shards for fast tests."""
+    zs.init_store(
+        store_path=store_path,
+        zone_numbers=[10],
+        years=[2024, 2025],
+        model_url=MODEL_URL,
+        source_data=SOURCE_DATA,
+        resolution=RESOLUTION,
+        tile_size=TILE_SIZE,
+        dimensions=dimensions,
+        shard_size=512,
+        chunk_size=256,
+    )
+
+
+def test_build_geoemb_attrs_has_required_fields() -> None:
+    """build_geoemb_attrs includes all required geoemb fields with correct values."""
+    attrs = zs.build_geoemb_attrs(
+        dimensions=128,
+        model_url=MODEL_URL,
+        source_data=SOURCE_DATA,
+        gsd=10.0,
+        build_version="0.0.1",
+    )
+    for field in REQUIRED_GEOEMB_FIELDS:
+        assert field in attrs
+    assert attrs["geoemb:type"] == "pixel"
+    assert attrs["geoemb:dimensions"] == 128
+    assert attrs["geoemb:data_type"] == "int8"
+    assert attrs["geoemb:spatial_layout"] == "utm_zones"
+    quant = attrs["geoemb:quantization"]
+    # Quantization object requires method and original_dtype.
+    assert quant["method"] == "signed_power"
+    assert quant["original_dtype"] == "float32"
+
+
+def test_build_zone_spatial_attrs_transform() -> None:
+    """The zone affine maps the array corner to the expected CRS coordinates."""
+    projection, origin, shape = get_zone_grid(10, RESOLUTION, TILE_SIZE)
+    attrs = zs.build_zone_spatial_attrs(projection, origin, shape)
+    origin_x, origin_y = origin
+    height, width = shape
+    assert attrs["proj:code"] == "EPSG:32610"
+    assert attrs["spatial:shape"] == [height, width]
+    # transform = [x_res, 0, corner_easting, 0, y_res, corner_northing].
+    transform = attrs["spatial:transform"]
+    assert transform[0] == RESOLUTION
+    assert transform[4] == -RESOLUTION
+    assert transform[2] == origin_x * RESOLUTION
+    assert transform[5] == origin_y * -RESOLUTION
+
+
+def test_init_store_root_and_zone_attrs(tmp_path) -> None:
+    """init_store writes conforming root and zone-group attributes."""
+    store = str(tmp_path / "emb.zarr")
+    _init_small_store(store)
+
+    root = zarr.open_group(store=store, mode="r")
+    assert isinstance(root.attrs["zarr_conventions"], list)
+    convention_names = {entry["name"] for entry in root.attrs["zarr_conventions"]}
+    assert "geoemb:" in convention_names
+    for field in REQUIRED_GEOEMB_FIELDS:
+        assert field in root.attrs
+
+    zone = zarr.open_group(store=store, path="utm10", mode="r")
+    assert zone.attrs["proj:code"] == "EPSG:32610"
+    assert len(zone.attrs["spatial:transform"]) == 6
+    # geoemb attrs are replicated on the zone group so it is self-describing.
+    assert zone.attrs["geoemb:type"] == "pixel"
+
+
+def test_init_store_array_layout(tmp_path) -> None:
+    """The embedding array has the expected dims, dtype, fill value, and sharding."""
+    store = str(tmp_path / "emb.zarr")
+    _init_small_store(store, dimensions=4)
+    _, _, shape = get_zone_grid(10, RESOLUTION, TILE_SIZE)
+    height, width = shape
+
+    array = zarr.open_group(store=store, path="utm10", mode="r")[zs.EMBEDDINGS_ARRAY]
+    assert array.shape == (2, 4, height, width)
+    assert array.dtype == np.int8
+    assert array.fill_value == zs.NODATA_VALUE
+    assert array.shards == (1, 4, 512, 512)
+    assert array.chunks == (1, 4, 256, 256)
+
+
+def test_write_window_region_roundtrip(tmp_path) -> None:
+    """A written window round-trips, and unwritten regions read as nodata."""
+    store = str(tmp_path / "emb.zarr")
+    _init_small_store(store, dimensions=4)
+    _, origin, _ = get_zone_grid(10, RESOLUTION, TILE_SIZE)
+    origin_x, origin_y = origin
+
+    bx0 = origin_x + 10 * 512
+    by0 = origin_y + 100 * 512
+    window_bounds = (bx0, by0, bx0 + 512, by0 + 512)
+    embeddings = np.random.randint(-127, 128, size=(4, 512, 512)).astype(np.int8)
+    zs.write_window_region(store, 10, window_bounds, time_index=1, embeddings=embeddings)
+
+    array = zarr.open_group(store=store, path="utm10", mode="r")[zs.EMBEDDINGS_ARRAY]
+    col0 = bx0 - origin_x
+    row0 = by0 - origin_y
+    written = array[1, :, row0 : row0 + 512, col0 : col0 + 512]
+    assert np.array_equal(written, embeddings)
+    # Same location at the other (unwritten) time index is nodata.
+    assert (array[0, :, row0 : row0 + 4, col0 : col0 + 4] == zs.NODATA_VALUE).all()
+
+
+def test_disjoint_writes_do_not_interfere(tmp_path) -> None:
+    """Two windows written to disjoint shards both round-trip correctly."""
+    store = str(tmp_path / "emb.zarr")
+    _init_small_store(store, dimensions=4)
+    _, origin, _ = get_zone_grid(10, RESOLUTION, TILE_SIZE)
+    origin_x, origin_y = origin
+
+    windows = []
+    for shard_col, shard_row in [(10, 100), (12, 100)]:
+        bx0 = origin_x + shard_col * 512
+        by0 = origin_y + shard_row * 512
+        emb = np.random.randint(-127, 128, size=(4, 512, 512)).astype(np.int8)
+        zs.write_window_region(
+            store, 10, (bx0, by0, bx0 + 512, by0 + 512), time_index=0, embeddings=emb
+        )
+        windows.append((bx0, by0, emb))
+
+    array = zarr.open_group(store=store, path="utm10", mode="r")[zs.EMBEDDINGS_ARRAY]
+    for bx0, by0, emb in windows:
+        col0 = bx0 - origin_x
+        row0 = by0 - origin_y
+        back = array[0, :, row0 : row0 + 512, col0 : col0 + 512]
+        assert np.array_equal(back, emb)
+
+
+def test_write_window_region_patch_size(tmp_path) -> None:
+    """With patch_size>1 the store grid is at the output resolution.
+
+    The store is created at 1/patch_size resolution and an input-pixel window lands at
+    its input bounds divided by patch_size.
+    """
+    patch_size = 4
+    window_size_px = 2048  # PATCH_SIZE, in input pixels.
+    out_px = window_size_px // patch_size
+    store = str(tmp_path / "emb.zarr")
+    out_resolution = RESOLUTION * patch_size
+    out_tile_size = TILE_SIZE // patch_size
+    zs.init_store(
+        store_path=store,
+        zone_numbers=[10],
+        years=[2024],
+        model_url=MODEL_URL,
+        source_data=SOURCE_DATA,
+        resolution=out_resolution,
+        tile_size=out_tile_size,
+        dimensions=4,
+        shard_size=out_px,
+        chunk_size=256,
+    )
+
+    # The input grid (10 m) origin maps to the output grid origin by // patch_size.
+    _, in_origin, _ = get_zone_grid(10, RESOLUTION, TILE_SIZE)
+    _, out_origin, _ = get_zone_grid(10, out_resolution, out_tile_size)
+    assert out_origin[0] == in_origin[0] // patch_size
+    assert out_origin[1] == in_origin[1] // patch_size
+
+    # An input-pixel window yields an out_px raster placed at input_bounds//patch_size.
+    bx0 = in_origin[0] + 3 * window_size_px
+    by0 = in_origin[1] + 5 * window_size_px
+    window_bounds = (bx0, by0, bx0 + window_size_px, by0 + window_size_px)
+    embeddings = np.random.randint(-127, 128, size=(4, out_px, out_px)).astype(np.int8)
+    zs.write_window_region(
+        store,
+        10,
+        window_bounds,
+        time_index=0,
+        embeddings=embeddings,
+        patch_size=patch_size,
+    )
+
+    array = zarr.open_group(store=store, path="utm10", mode="r")[zs.EMBEDDINGS_ARRAY]
+    out_ox, out_oy = out_origin
+    col0 = bx0 // patch_size - out_ox
+    row0 = by0 // patch_size - out_oy
+    back = array[0, :, row0 : row0 + out_px, col0 : col0 + out_px]
+    assert np.array_equal(back, embeddings)

--- a/tests/unit/large_scale_embeddings/test_zarr_store.py
+++ b/tests/unit/large_scale_embeddings/test_zarr_store.py
@@ -1,5 +1,7 @@
 """Unit tests for rslp.large_scale_embeddings.zarr_store."""
 
+from pathlib import Path
+
 import numpy as np
 import zarr
 
@@ -74,7 +76,7 @@ def test_build_zone_spatial_attrs_transform() -> None:
     assert transform[5] == origin_y * -RESOLUTION
 
 
-def test_init_store_root_and_zone_attrs(tmp_path) -> None:
+def test_init_store_root_and_zone_attrs(tmp_path: Path) -> None:
     """init_store writes conforming root and zone-group attributes."""
     store = str(tmp_path / "emb.zarr")
     _init_small_store(store)
@@ -93,7 +95,7 @@ def test_init_store_root_and_zone_attrs(tmp_path) -> None:
     assert zone.attrs["geoemb:type"] == "pixel"
 
 
-def test_init_store_array_layout(tmp_path) -> None:
+def test_init_store_array_layout(tmp_path: Path) -> None:
     """The embedding array has the expected dims, dtype, fill value, and sharding."""
     store = str(tmp_path / "emb.zarr")
     _init_small_store(store, dimensions=4)
@@ -108,7 +110,7 @@ def test_init_store_array_layout(tmp_path) -> None:
     assert array.chunks == (1, 4, 256, 256)
 
 
-def test_write_window_region_roundtrip(tmp_path) -> None:
+def test_write_window_region_roundtrip(tmp_path: Path) -> None:
     """A written window round-trips, and unwritten regions read as nodata."""
     store = str(tmp_path / "emb.zarr")
     _init_small_store(store, dimensions=4)
@@ -132,7 +134,7 @@ def test_write_window_region_roundtrip(tmp_path) -> None:
     assert (array[0, :, row0 : row0 + 4, col0 : col0 + 4] == zs.NODATA_VALUE).all()
 
 
-def test_disjoint_writes_do_not_interfere(tmp_path) -> None:
+def test_disjoint_writes_do_not_interfere(tmp_path: Path) -> None:
     """Two windows written to disjoint shards both round-trip correctly."""
     store = str(tmp_path / "emb.zarr")
     _init_small_store(store, dimensions=4)
@@ -157,7 +159,7 @@ def test_disjoint_writes_do_not_interfere(tmp_path) -> None:
         assert np.array_equal(back, emb)
 
 
-def test_write_window_region_patch_size(tmp_path) -> None:
+def test_write_window_region_patch_size(tmp_path: Path) -> None:
     """With patch_size>1 the store grid is at the output resolution.
 
     The store is created at 1/patch_size resolution and an input-pixel window lands at


### PR DESCRIPTION
Computes OlmoEarth embeddings over large areas (up to global scale) and writes them
directly to a GeoZarr store following the geoemb
[embeddings-zarr-convention](https://github.com/geo-embeddings/embeddings-zarr-convention),
replacing the per-window GeoTIFF output.

Embeddings are 10 m/pixel in each location's UTM projection, 128-dimensional,
L2-normalized, and quantized to int8 using the same power-based scheme as AlphaEarth
Foundations (section S8.1).

## Store layout

One Zarr v3 group per UTM zone number (`utm01`-`utm60`), each holding an `embeddings`
array indexed `(time, band, y, x)`. Each zone is stored in its **northern** CRS with a
continuous northing axis that goes negative south of the equator, so one group covers
both hemispheres. That is only a false-northing shift, so it costs nothing in
distortion and halves the number of groups.

The array is sharded so that **one shard equals one 2048x2048 prediction window**, with
256x256 inner chunks and zstd compression. It is sparse: only shards intersecting land
inside the requested area are written, and everything else reads back as the -128
nodata value.

## Design points worth review attention

- **One shard per window** is a correctness requirement, not a tuning choice. If two
  windows shared a shard, two workers finishing concurrently would each read-modify-write
  the same object and one would silently clobber the other. Matching them makes every
  write a whole object owned by exactly one worker, which is what allows concurrent
  writers with no locking.
- **`init_store` writes all metadata up front** (root, zone groups, arrays,
  coordinates), so prediction workers only ever write data regions and never mutate
  metadata.
- **Completion markers are the ledger.** `get_jobs` derives remaining work by listing
  markers, and `predict` returns immediately when a marker exists, so jobs are
  idempotent and re-enqueuing is always safe.
- **`job_size`** subdivides the existing 32768 tile grid rather than re-gridding the
  zone, so absolute pixel coordinates stay identical to what the store was created with.
  It is a bet on worker lifetime, not an efficiency dial: bigger jobs amortize model load
  and compilation over more windows, but a job only counts if it finishes. On
  preemptible workers 32768 never completed, while 8192 (16 windows, ~38 min) completes
  reliably.
- **`supervise`** keeps a long run moving without a human: it recomputes remaining work
  from markers, tops the queue up only when shallow, and refills the worker pool. Each
  cycle runs in a spawned child the parent kills at 600 s, because the Beaker client has
  no RPC timeout and `signal.alarm` cannot interrupt a blocked gRPC call. Two earlier
  in-process watchdog attempts stalled for ~10 h each.
- **The queue is kept deliberately shallow.** A Beaker queue entry claimed by a worker
  that then dies is not released; entries were still CLAIMED 5 h after being claimed with
  no worker alive for the last 1.4 of those. They age out via `status.expiry` (7 days
  default), far longer than any job, and `max_claimed_entries=1` means a dead claim
  occupies that entry's only slot. Enqueuing a whole run up front bled work steadily
  (one attempt accumulated 327 orphans).

## Validation

A full run over the `initial_regions` areas for 2024 and 2025 completed 1080/1080
blocks, 6.17 TB. Per written window the store averages ~385 MB against 1.07 GB for the
equivalent uncompressed int16 GeoTIFF, a measured zstd ratio of 0.717 (range
0.534-0.794 by terrain). The int16 to int8 conversion was checked to be lossless for
this data: no value read from the GeoTIFF outputs exceeds +/-72, comfortably inside
int8. Dequantized per-pixel L2 norms come back at ~1.0.

18 unit tests cover the tiling wedge logic, the quantization scheme, and store
init/write/roundtrip including disjoint concurrent-style writes.

## Known issues, documented in the README

- **Embeddings do not reproduce exactly across runs.** On windows shared with the
  earlier GeoTIFF run, cosine similarity came out 0.948 and 0.852 rather than ~1.0,
  with the same checkpoint and the same patch/window/overlap settings. Leading
  candidates are Sentinel-2 mosaic selection drifting between runs and dependency drift
  between container images. Unresolved.
- **Roughly 68% of worker attempts exit on a signal** (137/139) rather than preemption
  (143). Retries absorb it and the run completes, but the GPU cost is real. Memory
  pressure from co-location is the leading theory and the materialize pool has been
  ruled out; the cheapest next experiment is more GPUs per worker.
- `MATERIALIZE_PIPELINE_ARGS` pool sizes are the working default. Scaling them to a
  job's window count was tried and reverted, but the revert rested on a mismeasured
  elapsed time, so the change is neither proven harmful nor proven safe.

## Notes for reviewers

- This branch **builds on 5 unmerged commits by Favyen Bastani** (`e2cb75db`..`d330bd22`),
  which are included here so the feature lands as a whole.
- The **`olmoearth_pretrain.Dockerfile` change has the widest blast radius** in the
  diff: it bumps torch 2.7.0 to 2.10.0 and adds `--break-system-packages`, affecting
  every project building from that image. `requirements.txt` also gains a repo-wide
  `jsonargparse<4.50` upper bound, needed because 4.50 dropped the `cfg_str` positional
  that rslearn's parser override relies on.
- Minor gotcha for anyone running the hooks locally: line 1 of
  `.pre-commit-config.yaml` has an invalid root key `exclude_types`, which makes
  `pre-commit run ruff --files ...` report "no files to check" and silently pass. CI
  uses `--all-files`, where the hooks run normally, so use that locally to match CI.
